### PR TITLE
Bring back the relative position calculation to have reasonable error messages

### DIFF
--- a/crates/codegen/src/irgen/statements.rs
+++ b/crates/codegen/src/irgen/statements.rs
@@ -165,7 +165,7 @@ pub fn statement_gen<'a>(
                     // Special case:
                     // If the macro provided to __codesize is the current macro, we need to avoid a
                     // circular reference If this is the case we will store a
-                    // place holder inside the bytecode and fill it in later when
+                    // placeholder inside the bytecode and fill it in later when
                     // we have adequate information about the macros eventual size.
                     // We also need to avoid if the codesize arg is any of the previous macros to
                     // avoid a circular reference

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -312,7 +312,7 @@ impl<'a, 'l> Compiler<'a, 'l> {
 
                 // Perform Lexical Analysis
                 // Create a new lexer from the FileSource, flattening dependencies
-                let lexer = Lexer::new(full_source.source, Some(file.clone()));
+                let lexer = Lexer::new(full_source);
 
                 // Grab the tokens from the lexer
                 let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -346,7 +346,7 @@ impl<'a, 'l> Compiler<'a, 'l> {
 
         // Perform Lexical Analysis
         // Create a new lexer from the FileSource, flattening dependencies
-        let lexer = Lexer::new(full_source.source, Some(file.clone()));
+        let lexer = Lexer::new(full_source);
 
         // Grab the tokens from the lexer
         let mut tokens = Vec::new();

--- a/crates/core/tests/alternative_constructor_macro.rs
+++ b/crates/core/tests/alternative_constructor_macro.rs
@@ -18,7 +18,7 @@ fn test_alternative_constructor_macro_provided() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();

--- a/crates/core/tests/alternative_main_macro.rs
+++ b/crates/core/tests/alternative_main_macro.rs
@@ -18,7 +18,7 @@ fn test_alternative_main_macro_provided() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();

--- a/crates/core/tests/breaking_jumptable.rs
+++ b/crates/core/tests/breaking_jumptable.rs
@@ -133,7 +133,7 @@ fn test_breaking_jump_table() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 

--- a/crates/core/tests/builtins.rs
+++ b/crates/core/tests/builtins.rs
@@ -24,7 +24,7 @@ fn test_codesize_builtin() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -59,7 +59,7 @@ fn test_dyn_constructor_arg_builtin() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -149,7 +149,7 @@ fn test_tablesize_builtin() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -213,7 +213,7 @@ fn test_tablestart_builtin() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -277,7 +277,7 @@ fn test_jump_table_exhaustive_usage() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -337,7 +337,7 @@ fn test_jump_table_packed_exhaustive_usage() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -404,7 +404,7 @@ fn test_label_clashing() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -448,7 +448,7 @@ fn test_func_sig_builtin() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -488,7 +488,7 @@ fn test_event_hash_builtin() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -559,7 +559,7 @@ fn test_error_selector_builtin() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -599,7 +599,7 @@ fn test_rightpad_builtin() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 

--- a/crates/core/tests/codegen_errors.rs
+++ b/crates/core/tests/codegen_errors.rs
@@ -33,7 +33,7 @@ fn test_storage_pointers_not_derived() {
     // let const_end = const_start + "UNKNOWN_CONSTANT_DEFINITION".len();
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let contract = parser.parse().unwrap();
@@ -92,7 +92,7 @@ fn test_invalid_constant_definition() {
     let const_end = const_start + "UNKNOWN_CONSTANT_DEFINITION".len() - 1;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();
@@ -133,7 +133,7 @@ fn test_missing_constructor() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();
@@ -166,7 +166,7 @@ fn test_missing_main() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();
@@ -199,7 +199,7 @@ fn test_missing_when_alternative_main_provided() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();
@@ -242,7 +242,7 @@ fn test_unknown_macro_definition() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();
@@ -289,7 +289,7 @@ fn test_unmatched_jump_label() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();

--- a/crates/core/tests/compiling.rs
+++ b/crates/core/tests/compiling.rs
@@ -40,7 +40,7 @@ const SOURCE: &str = r#"
 fn compiles_constructor_bytecode() {
     // Lex and Parse the source code
     let flattened_source = FullFileSource { source: SOURCE, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -66,7 +66,7 @@ fn compiles_constructor_bytecode() {
 fn compiles_runtime_bytecode() {
     // Lex and Parse the source code
     let flattened_source = FullFileSource { source: SOURCE, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 

--- a/crates/core/tests/erc20.rs
+++ b/crates/core/tests/erc20.rs
@@ -20,7 +20,7 @@ fn test_erc20_compile() {
     let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./"), file_provider).unwrap();
     let flattened = FileSource::fully_flatten(Arc::clone(&recursed_file_source));
     let full_source = FullFileSource { source: &flattened.0, file: Some(Arc::clone(file_source)), spans: flattened.1 };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("../../huff-examples/erc20/contracts".to_string()));
     let mut contract = parser.parse().unwrap();

--- a/crates/core/tests/erc721.rs
+++ b/crates/core/tests/erc721.rs
@@ -20,7 +20,7 @@ fn test_erc721_compile() {
     let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./"), file_provider).unwrap();
     let flattened = FileSource::fully_flatten(Arc::clone(&recursed_file_source));
     let full_source = FullFileSource { source: &flattened.0, file: Some(Arc::clone(file_source)), spans: flattened.1 };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("../../huff-examples/erc20/contracts".to_string()));
     let mut contract = parser.parse().unwrap();

--- a/crates/core/tests/exports_events.rs
+++ b/crates/core/tests/exports_events.rs
@@ -16,7 +16,7 @@ fn test_abi_uint_events() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();
@@ -56,7 +56,7 @@ fn test_abi_int_events() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();
@@ -96,7 +96,7 @@ fn test_abi_simple_events() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();
@@ -135,7 +135,7 @@ fn test_abi_tuple_array_events() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();
@@ -174,7 +174,7 @@ fn test_abi_nested_tuple_array_events() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();

--- a/crates/core/tests/free_storage_pointer.rs
+++ b/crates/core/tests/free_storage_pointer.rs
@@ -24,7 +24,7 @@ fn test_set_free_storage_pointers() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 

--- a/crates/core/tests/functions.rs
+++ b/crates/core/tests/functions.rs
@@ -93,7 +93,7 @@ fn test_function() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -186,7 +186,7 @@ fn test_nested_function() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 

--- a/crates/core/tests/macro_invoc_args.rs
+++ b/crates/core/tests/macro_invoc_args.rs
@@ -19,7 +19,7 @@ fn test_opcode_macro_args() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();
@@ -57,7 +57,7 @@ fn test_all_opcodes_in_macro_args() {
 
         // Lex + Parse
         let flattened_source = FullFileSource { source: &source, file: None, spans: vec![] };
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
         let mut parser = Parser::new(tokens, None);
         let mut contract = parser.parse().unwrap();
@@ -95,7 +95,7 @@ fn test_constant_macro_arg() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();
@@ -135,7 +135,7 @@ fn test_bubbled_label_call_macro_arg() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();
@@ -174,7 +174,7 @@ fn test_bubbled_literal_macro_arg() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();
@@ -213,7 +213,7 @@ fn test_bubbled_opcode_macro_arg() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();
@@ -254,7 +254,7 @@ fn test_bubbled_constant_macro_arg() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();
@@ -291,7 +291,7 @@ fn test_bubbled_arg_with_different_name() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();

--- a/crates/core/tests/parser_errors.rs
+++ b/crates/core/tests/parser_errors.rs
@@ -28,7 +28,7 @@ fn test_invalid_macro_statement() {
     let const_end = const_start + "FREE_STORAGE_POINTER()".len() - 1;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
 
@@ -54,7 +54,7 @@ fn test_unexpected_type() {
     let source = "#define function func() internal returns ()";
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
 
@@ -83,7 +83,7 @@ fn test_invalid_definition() {
     let source = "#define invalid func() returns ()";
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
 
@@ -127,7 +127,7 @@ fn test_invalid_constant_value() {
         let source = &format!("#define constant CONSTANT = {value}");
 
         let full_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(full_source.source, None);
+        let lexer = Lexer::new(full_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
         let mut parser = Parser::new(tokens, Some("".to_string()));
 
@@ -172,7 +172,7 @@ fn test_invalid_token_in_macro_body() {
         );
 
         let full_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(full_source.source, None);
+        let lexer = Lexer::new(full_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
         let mut parser = Parser::new(tokens, Some("".to_string()));
 
@@ -218,7 +218,7 @@ fn test_invalid_token_in_label_definition() {
         );
 
         let full_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(full_source.source, None);
+        let lexer = Lexer::new(full_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
         let mut parser = Parser::new(tokens, Some("".to_string()));
 
@@ -253,7 +253,7 @@ fn test_invalid_single_arg() {
         let source = &format!("#define macro CONSTANT() = takes ({random_char}) returns (0) {{}}");
 
         let full_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(full_source.source, None);
+        let lexer = Lexer::new(full_source);
         let tokens = lexer
             .into_iter()
             .map(|x| match x {

--- a/crates/core/tests/push_overrides.rs
+++ b/crates/core/tests/push_overrides.rs
@@ -15,7 +15,7 @@ fn test_gracefully_pads_push_override() {
 
     // Lex and Parse the source code
     let flattened_source = FullFileSource { source: OVERRIDEN_PUSH, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -48,7 +48,7 @@ fn test_constructs_exact_push_override() {
 
     // Lex and Parse the source code
     let flattened_source = FullFileSource { source: OVERRIDEN_PUSH, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -81,7 +81,7 @@ fn test_no_push0_override() {
 
     // Lex and Parse the source code
     let flattened_source = FullFileSource { source: OVERRIDEN_PUSH, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -113,7 +113,7 @@ fn test_fails_on_push_underflow() {
     "#;
 
     let flattened_source = FullFileSource { source: OVERRIDEN_PUSH, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     parser.parse().unwrap();
@@ -136,7 +136,7 @@ fn test_literal_to_push0() {
     "#;
 
     let flattened_source = FullFileSource { source: LITERAL_PUSH, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 

--- a/crates/core/tests/recurse_bytecode.rs
+++ b/crates/core/tests/recurse_bytecode.rs
@@ -46,7 +46,7 @@ fn recurse_macro_bytecode() {
 
     // Lex + Parse
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();

--- a/crates/core/tests/test_circular_constructor.rs
+++ b/crates/core/tests/test_circular_constructor.rs
@@ -37,7 +37,7 @@ fn test_circular_large_constructors() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();
@@ -85,7 +85,7 @@ fn test_circular_constructor_at_word_boundry() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();
@@ -118,7 +118,7 @@ fn test_double_circular_constructor_multiple_macro_invocations() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();
@@ -155,7 +155,7 @@ fn test_double_circular_constructor_nested_macro_invocations() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();

--- a/crates/core/tests/tests.rs
+++ b/crates/core/tests/tests.rs
@@ -24,7 +24,7 @@ fn test_invocation_should_fail() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 

--- a/crates/core/tests/verbatim.rs
+++ b/crates/core/tests/verbatim.rs
@@ -12,7 +12,7 @@ fn test_verbatim() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();
@@ -34,7 +34,7 @@ fn test_verbatim_invalid_hex() {
     "#;
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let mut contract = parser.parse().unwrap();

--- a/crates/lexer/tests/arg_calls.rs
+++ b/crates/lexer/tests/arg_calls.rs
@@ -16,7 +16,7 @@ fn lexes_arg_calls() {
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
 
     // Parse tokens
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // Eat Tokens
     let _ = lexer.next(); // Whitespace

--- a/crates/lexer/tests/builtins.rs
+++ b/crates/lexer/tests/builtins.rs
@@ -16,7 +16,7 @@ fn parses_builtin_function_in_macro_body() {
             "{", "}",
         );
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         let _ = lexer.next(); // whitespace
         let _ = lexer.next(); // #define
@@ -70,7 +70,7 @@ fn fails_to_parse_builtin_outside_macro_body() {
     for builtin in builtin_funcs {
         let source = &format!("{builtin}(MAIN)");
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
@@ -101,7 +101,7 @@ fn fails_to_parse_invalid_builtin() {
             "{", "}",
         );
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         let _ = lexer.next(); // whitespace
         let _ = lexer.next(); // #define

--- a/crates/lexer/tests/comments.rs
+++ b/crates/lexer/tests/comments.rs
@@ -14,7 +14,7 @@ use huff_neo_utils::prelude::*;
 fn instantiates() {
     let source = "#define macro HELLO_WORLD()";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     assert!(!lexer.eof);
 }
 
@@ -22,7 +22,7 @@ fn instantiates() {
 fn single_line_comments() {
     let source = "// comment contents \n#define macro HELLO_WORLD()";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first token should be a single line comment
     let tok = lexer.next();
@@ -91,7 +91,7 @@ fn single_line_comments() {
 fn multi_line_comments() {
     let source = "/* comment contents*/#define macro HELLO_WORLD()";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first token should be a single line comment
     let tok = lexer.next();

--- a/crates/lexer/tests/context.rs
+++ b/crates/lexer/tests/context.rs
@@ -6,7 +6,7 @@ use huff_neo_utils::prelude::*;
 fn function_context() {
     let source = "#define function test(bytes32) {} returns (address)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
     // check input
@@ -19,7 +19,7 @@ fn function_context() {
 fn event_context() {
     let source = "#define event Transfer(bytes32,address)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
     assert_eq!(tokens.get(tokens.len() - 5).unwrap().kind, TokenKind::PrimitiveType(PrimitiveEVMType::Bytes(32)));
@@ -30,7 +30,7 @@ fn event_context() {
 fn macro_context() {
     let source = "#define macro TEST() = takes (0) returns (0) {byte}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
     assert_eq!(tokens.get(tokens.len() - 3).unwrap().kind, TokenKind::Opcode(Opcode::Byte));
 }

--- a/crates/lexer/tests/decorators.rs
+++ b/crates/lexer/tests/decorators.rs
@@ -17,7 +17,7 @@ fn parses_decorator() {
         );
 
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         let _ = lexer.next(); // whitespace
 
@@ -118,7 +118,7 @@ fn fails_to_parse_decorator_in_body() {
         );
 
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         for token in lexer.by_ref() {
             if let Err(e) = token {

--- a/crates/lexer/tests/eof.rs
+++ b/crates/lexer/tests/eof.rs
@@ -5,7 +5,7 @@ use huff_neo_utils::prelude::*;
 fn end_of_file() {
     let source = " ";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // Eats the whitespace
     let _ = lexer.next();

--- a/crates/lexer/tests/evm_types.rs
+++ b/crates/lexer/tests/evm_types.rs
@@ -16,7 +16,7 @@ fn primitive_type_parsing() {
     for (evm_type, evm_type_enum) in evm_types {
         let source = &format!("#define function test({evm_type}) view returns (uint256)");
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
         assert_eq!(tokens.get(4).unwrap().kind, TokenKind::PrimitiveType(evm_type_enum));
@@ -38,7 +38,7 @@ fn bounded_array_parsing() {
     for (evm_type, evm_type_enum) in evm_types {
         let source = &format!("#define function test({evm_type}) view returns (uint256)");
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
         assert_eq!(tokens.get(4).unwrap().kind, evm_type_enum);
@@ -60,7 +60,7 @@ fn unbounded_array_parsing() {
     for (evm_type, evm_type_enum) in evm_types {
         let source = &format!("#define function test({evm_type}) view returns (uint256)");
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
         assert_eq!(tokens.get(4).unwrap().kind, evm_type_enum);
     }
@@ -81,7 +81,7 @@ fn multidim_array_parsing() {
     for (evm_type, evm_type_enum) in evm_types {
         let source = &format!("#define function test({evm_type}) view returns (uint256)");
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
         assert_eq!(tokens.get(4).unwrap().kind, evm_type_enum);

--- a/crates/lexer/tests/fsp.rs
+++ b/crates/lexer/tests/fsp.rs
@@ -5,7 +5,7 @@ use huff_neo_utils::prelude::*;
 fn free_storage_pointer() {
     let source = "FREE_STORAGE_POINTER() ";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first token should be the fsp
     let tok = lexer.next().unwrap().unwrap();

--- a/crates/lexer/tests/function_type.rs
+++ b/crates/lexer/tests/function_type.rs
@@ -9,7 +9,7 @@ fn parses_function_type() {
     for (fn_type, fn_type_kind) in fn_types {
         let source = &format!("#define function test() {fn_type} returns (uint256)");
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         let _ = lexer.next(); // #define
         let _ = lexer.next(); // whitespace

--- a/crates/lexer/tests/hex.rs
+++ b/crates/lexer/tests/hex.rs
@@ -5,7 +5,7 @@ use huff_neo_utils::prelude::*;
 fn parses_single_hex() {
     let source = "0xa57B";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first and only token should be lexed as Literal(0xa57B)
     let tok = lexer.next().unwrap().unwrap();
@@ -20,7 +20,7 @@ fn parses_single_hex() {
 fn parses_bool() {
     let source = "false true";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first token should be lexed as a Literal representing 0x00
     let tok = lexer.next().unwrap().unwrap();
@@ -41,7 +41,7 @@ fn parses_bool() {
 fn parses_odd_len_hex() {
     let source = "0x1";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first and only token should be lexed as Literal(0x1)
     let tok = lexer.next().unwrap().unwrap();

--- a/crates/lexer/tests/imports.rs
+++ b/crates/lexer/tests/imports.rs
@@ -94,7 +94,7 @@ fn lex_imports_empty_quotes() {
 fn include_no_quotes() {
     let source = "#include";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first token should be a single line comment
     let tok = lexer.next();
@@ -108,7 +108,7 @@ fn include_no_quotes() {
 fn include_with_string() {
     let source = "#include \"../../huff-examples/erc20/contracts/utils/Ownable.huff\"";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first token should be a single line comment
     let tok = lexer.next();
@@ -137,7 +137,7 @@ fn include_with_string() {
 fn include_with_string_single_quote() {
     let source = "#include '../../huff-examples/erc20/contracts/utils/Ownable.huff'";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first token should be a single line comment
     let tok = lexer.next();

--- a/crates/lexer/tests/keywords.rs
+++ b/crates/lexer/tests/keywords.rs
@@ -5,7 +5,7 @@ use huff_neo_utils::prelude::*;
 fn parses_macro_keyword() {
     let source = "#define macro";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // Define Identifier first
     let tok = lexer.next();
@@ -35,7 +35,7 @@ fn parses_macro_keyword() {
 fn parses_fn_keyword() {
     let source = "#define fn";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // Define Identifier first
     let tok = lexer.next();
@@ -65,7 +65,7 @@ fn parses_fn_keyword() {
 fn parses_test_keyword() {
     let source = "#define test";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // Define Identifier first
     let tok = lexer.next();
@@ -95,7 +95,7 @@ fn parses_test_keyword() {
 fn parses_function_keyword() {
     let source = "#define function";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // Define Identifier first
     let tok = lexer.next();
@@ -125,7 +125,7 @@ fn parses_function_keyword() {
 fn parses_event_keyword() {
     let source = "#define event TestEvent(uint256)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // Define Identifier first
     let tok = lexer.next();
@@ -160,7 +160,7 @@ fn parses_event_keyword() {
 fn parses_constant_keyword() {
     let source = "#define constant";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // Define Identifier first
     let tok = lexer.next();
@@ -190,7 +190,7 @@ fn parses_constant_keyword() {
 fn parses_takes_and_returns_keywords() {
     let source = "#define macro TEST() = takes   (0)   returns   (0)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     let _ = lexer.next(); // #define
     let _ = lexer.next(); // whitespace
@@ -237,7 +237,7 @@ fn parses_takes_and_returns_keywords() {
 fn parses_takes_and_returns_keywords_tight_syntax() {
     let source = "#define macro TEST() = takes(0) returns(0)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     let _ = lexer.next(); // #define
     let _ = lexer.next(); // whitespace
@@ -282,7 +282,7 @@ fn parses_takes_and_returns_keywords_tight_syntax() {
 fn parses_function_type_keywords() {
     let source = "#define function test() view returns (uint256)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     let _ = lexer.next(); // #define
     let _ = lexer.next(); // whitespace
@@ -336,7 +336,7 @@ fn parses_function_definition_with_keyword_name() {
     for s in key_words {
         let source = &format!("#define function {s}(uint256) view returns(uint256)");
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         let end_span_s = 17 + s.len();
 
@@ -408,7 +408,7 @@ fn parses_label_with_keyword_name() {
         );
 
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
@@ -458,7 +458,7 @@ fn parses_function_with_keyword_name() {
         let source = &format!("dup1 0x7c09063f eq {s} jumpi");
 
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         let _ = lexer.next(); // dup1
         let _ = lexer.next(); // whitespace
@@ -515,7 +515,7 @@ fn parses_function_with_keyword_name_in_macro() {
         );
 
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         let _ = lexer.next(); // whitespace
         let _ = lexer.next(); // #define
@@ -595,7 +595,7 @@ fn parses_keyword_arbitrary_whitespace() {
         let source = &format!("#define     {key}");
 
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let mut lexer = Lexer::new(flattened_source.source, None);
+        let mut lexer = Lexer::new(flattened_source);
 
         // Define Identifier first
         let tok = lexer.next();
@@ -626,7 +626,7 @@ fn parses_keyword_arbitrary_whitespace() {
 fn parses_takes_keyword_arbitrary_whitespace() {
     let source = "#define macro TEST() =      takes (0) returns (0)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     let _ = lexer.next(); // #define
     let _ = lexer.next(); // whitespace

--- a/crates/lexer/tests/labels.rs
+++ b/crates/lexer/tests/labels.rs
@@ -5,7 +5,7 @@ use huff_neo_utils::prelude::*;
 fn parse_label() {
     let source = "#define macro HELLO_WORLD() = takes(3) returns(0) {\n0x00 mstore\n 0x01 0x02 add cool_label:\n0x01\n}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
     assert_eq!(tokens.get(tokens.len() - 5).unwrap().kind, TokenKind::Label("cool_label".to_string()));
@@ -16,7 +16,7 @@ fn parse_label() {
 fn parse_label_with_opcode_name() {
     let source = "#define macro HELLO_WORLD() = takes(3) returns(0) {\n0x00 mstore\n 0x01 0x02 add cool_label_return_swap1_mload:\n0x01\n}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
     assert_eq!(tokens.get(tokens.len() - 5).unwrap().kind, TokenKind::Label("cool_label_return_swap1_mload".to_string()));

--- a/crates/lexer/tests/numbers.rs
+++ b/crates/lexer/tests/numbers.rs
@@ -5,7 +5,7 @@ use huff_neo_utils::prelude::*;
 fn lexes_zero_prefixed_numbers() {
     let source = "00";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first and only token should be lexed as 0
     let tok = lexer.next().unwrap().unwrap();
@@ -21,7 +21,7 @@ fn lexes_zero_prefixed_numbers() {
 fn lexes_large_numbers() {
     let source = &format!("{}", usize::MAX);
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // The first and only token should be lexed
     let tok = lexer.next().unwrap().unwrap();

--- a/crates/lexer/tests/opcodes.rs
+++ b/crates/lexer/tests/opcodes.rs
@@ -18,7 +18,7 @@ fn opcodes() {
             "{", "}",
         );
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
 
         let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 

--- a/crates/lexer/tests/symbols.rs
+++ b/crates/lexer/tests/symbols.rs
@@ -5,7 +5,7 @@ use huff_neo_utils::prelude::*;
 fn lexes_assign_op() {
     let source = "#define constant TRANSFER_EVENT_SIGNATURE =";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // This token should be a Define identifier
     let tok = lexer.next();
@@ -58,7 +58,7 @@ fn lexes_assign_op() {
 fn lexes_brackets() {
     let source = "[TOTAL_SUPPLY_LOCATION] sload";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // This token should be the open bracket
     let tok = lexer.next();
@@ -98,7 +98,7 @@ fn lexes_braces() {
     "#;
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
 
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // Eat the non-brace tokens
     let _ = lexer.next(); // whitespace
@@ -157,7 +157,7 @@ fn lexes_math_ops() {
     // MATHS
     let source = r#"100 + 10 - 20 * 5 / 4"#;
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     // Eat the number and whitespace
     let _ = lexer.next();
@@ -215,7 +215,7 @@ fn lexes_math_ops() {
 fn lexes_commas() {
     let source = "test,test";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
     // Eat alphanumerics
     let _ = lexer.next();
 
@@ -237,7 +237,7 @@ fn lexes_commas() {
 fn lexes_comma_sparse() {
     let source = "test , test";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let mut lexer = Lexer::new(flattened_source.source, None);
+    let mut lexer = Lexer::new(flattened_source);
 
     let _ = lexer.next(); // alphanumerics
     let _ = lexer.next(); // whitespace

--- a/crates/lexer/tests/tables.rs
+++ b/crates/lexer/tests/tables.rs
@@ -5,7 +5,7 @@ use huff_neo_utils::prelude::*;
 fn parses_jump_table() {
     let source = "#define jumptable JUMP_TABLE()";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
     assert_eq!(tokens.first().unwrap().kind, TokenKind::Define);
@@ -19,7 +19,7 @@ fn parses_jump_table() {
 fn parses_packed_jump_table() {
     let source = "#define jumptable__packed JUMP_TABLE_PACKED()";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
     assert_eq!(tokens.first().unwrap().kind, TokenKind::Define);
@@ -33,7 +33,7 @@ fn parses_packed_jump_table() {
 fn parses_code_table() {
     let source = "#define table CODE_TABLE()";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
     assert_eq!(tokens.first().unwrap().kind, TokenKind::Define);

--- a/crates/parser/tests/abi.rs
+++ b/crates/parser/tests/abi.rs
@@ -7,7 +7,7 @@ fn build_abi_from_ast() {
     let source = "#define function test(uint256[2][],string) view returns(uint256)";
 
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let contract = parser.parse().unwrap();

--- a/crates/parser/tests/breaking_param_invocation.rs
+++ b/crates/parser/tests/breaking_param_invocation.rs
@@ -19,7 +19,7 @@ fn test_breaking_param_invocation() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -44,7 +44,7 @@ fn test_breaking_param_commas() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 

--- a/crates/parser/tests/constant.rs
+++ b/crates/parser/tests/constant.rs
@@ -6,7 +6,7 @@ use huff_neo_utils::prelude::*;
 fn test_parses_free_storage_pointer_constant() {
     let source = "#define constant FSP_LOCATION = FREE_STORAGE_POINTER()";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let contract = parser.parse().unwrap();
@@ -33,7 +33,7 @@ fn test_parses_free_storage_pointer_constant() {
 fn test_parses_literal_constant() {
     let source = "#define constant LITERAL = 0x8C5BE1E5EBEC7D5BD14F71427D1E84F3DD0314C0F7B2291E5B200AC8C7C3B925";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let contract = parser.parse().unwrap();

--- a/crates/parser/tests/error.rs
+++ b/crates/parser/tests/error.rs
@@ -6,7 +6,7 @@ use huff_neo_utils::prelude::*;
 fn test_parses_custom_error() {
     let source = "#define error TestError(uint256)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let contract = parser.parse().unwrap();
@@ -42,7 +42,7 @@ fn test_error_sel_no_param() {
     let source = "#define error NotOwner()";
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
     let contract = parser.parse().unwrap();

--- a/crates/parser/tests/event.rs
+++ b/crates/parser/tests/event.rs
@@ -6,7 +6,7 @@ use huff_neo_utils::{ast::EventDefinition, prelude::*};
 fn test_prefix_event_arg_names_with_reserved_keywords() {
     let source: &str = "#define event TestEvent(bytes4 indexed interfaceId, uint256 uintTest, bool stringMe, string boolean)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let expected_tokens: Vec<Token> = vec![
         Token { kind: TokenKind::Define, span: Span { start: 0, end: 6, file: None } },
@@ -220,7 +220,7 @@ fn test_parse_event() {
 
     for (source, expected) in sources {
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
         let mut parser = Parser::new(tokens, None);
         let _ = parser.match_kind(TokenKind::Define);

--- a/crates/parser/tests/function.rs
+++ b/crates/parser/tests/function.rs
@@ -194,7 +194,7 @@ fn parses_valid_function_definition() {
 
     for (index, source) in sources.into_iter().enumerate() {
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
         let mut parser = Parser::new(tokens, None);
         let _ = parser.match_kind(TokenKind::Define);
@@ -210,7 +210,7 @@ fn parses_valid_function_definition() {
 fn cannot_parse_invalid_function_definition() {
     let source = "#define function test(uint256) returns(uint256)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     parser.parse().unwrap();
@@ -222,7 +222,7 @@ fn test_functions_with_keyword_arg_names_errors() {
     // The function parameter's name is a reserved keyword; this should throw an error
     let source: &str = "#define function myFunc(uint256 uint256) pure returns(uint256)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     parser.parse().unwrap();
@@ -232,7 +232,7 @@ fn test_functions_with_keyword_arg_names_errors() {
 fn test_functions_with_argument_locations() {
     let source: &str = "#define function myFunc(string calldata test, uint256[] storage) pure returns(bytes memory)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     parser.parse().unwrap();
@@ -242,7 +242,7 @@ fn test_functions_with_argument_locations() {
 fn test_can_prefix_function_arg_names_with_reserved_keywords() {
     let source: &str = "#define function supportsInterface(bytes4 interfaceId) view returns (bool)";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let expected_tokens: Vec<Token> = vec![
         Token { kind: TokenKind::Define, span: Span { start: 0, end: 6, file: None } },

--- a/crates/parser/tests/imports.rs
+++ b/crates/parser/tests/imports.rs
@@ -6,7 +6,7 @@ use huff_neo_utils::prelude::*;
 fn parses_import() {
     let source = " /* .,*./. */  #include \"../../huff-examples/erc20/contracts/ERC20.huff\"";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let contract = parser.parse().unwrap();
@@ -25,7 +25,7 @@ fn parses_deep_imports() {
         #include "../../huff-examples/erc20/contracts/utils/Ownable.huff"
     "#;
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let contract = parser.parse().unwrap();

--- a/crates/parser/tests/labels.rs
+++ b/crates/parser/tests/labels.rs
@@ -14,7 +14,7 @@ fn multiline_labels() {
     }
     "#;
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -189,7 +189,7 @@ pub fn builtins_under_labels() {
     }
     "#;
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 

--- a/crates/parser/tests/macro.rs
+++ b/crates/parser/tests/macro.rs
@@ -6,7 +6,7 @@ use huff_neo_utils::{evm::Opcode, prelude::*};
 fn empty_macro() {
     let source = "#define macro HELLO_WORLD() = takes(0) returns(4) {}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -48,7 +48,7 @@ fn empty_macro() {
 fn empty_macro_without_takes_returns() {
     let source = "#define macro HELLO_WORLD() = {}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -82,7 +82,7 @@ fn empty_macro_without_takes_returns() {
 fn empty_macro_only_takes() {
     let source = "#define macro HELLO_WORLD() = takes(3) {}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -120,7 +120,7 @@ fn empty_macro_only_takes() {
 fn empty_macro_only_returns() {
     let source = "#define macro HELLO_WORLD() = returns(10) {}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -158,7 +158,7 @@ fn empty_macro_only_returns() {
 fn macro_with_simple_body() {
     let source = "#define macro HELLO_WORLD() = takes(3) returns(0) {\n0x00 mstore\n 0x01 0x02 add\n}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -233,7 +233,7 @@ fn macro_with_arg_calls() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -374,7 +374,7 @@ fn macro_labels() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -549,7 +549,7 @@ fn macro_invocation_with_arg_call() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -673,7 +673,7 @@ fn test_macro_opcode_arguments() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -743,7 +743,7 @@ fn macro_with_builtin_fn_call() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
 
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
@@ -805,7 +805,7 @@ fn macro_with_builtin_fn_call() {
 fn empty_outlined_macro() {
     let source = "#define fn HELLO_WORLD() = takes(0) returns(4) {}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
 
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
@@ -848,7 +848,7 @@ fn empty_outlined_macro() {
 fn outlined_macro_with_simple_body() {
     let source = "#define fn HELLO_WORLD() = takes(3) returns(0) {\n0x00 mstore\n 0x01 0x02 add\n}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -901,7 +901,7 @@ fn outlined_macro_with_simple_body() {
 fn empty_test() {
     let source = "#define test HELLO_WORLD() = takes(0) returns(4) {}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -943,7 +943,7 @@ fn empty_test() {
 fn test_with_simple_body() {
     let source = "#define test HELLO_WORLD() = takes(3) returns(0) {\n0x00 0x00 mstore\n 0x01 0x02 add\n}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -1021,7 +1021,7 @@ fn empty_test_with_decorator() {
     #define test MY_TEST() = takes(0) returns(0) {}
     "#;
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -1077,7 +1077,7 @@ fn empty_test_with_multi_flag_decorator() {
     #define test MY_TEST() = takes(0) returns(0) {}
     "#;
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -1172,7 +1172,7 @@ fn test_duplicate_macro_error() {
     }
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(full_source.source, None);
+    let lexer = Lexer::new(full_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, Some("".to_string()));
 

--- a/crates/parser/tests/opcodes.rs
+++ b/crates/parser/tests/opcodes.rs
@@ -17,7 +17,7 @@ fn not_mistaken_as_opcode() {
             "#
         );
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
 
         let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
 
@@ -45,7 +45,7 @@ fn test_invalid_push_non_literal() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
@@ -65,7 +65,7 @@ fn test_push_literals() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
 
     let expected_tokens = vec![
@@ -132,7 +132,7 @@ fn test_push0() {
 
     // Parse tokens
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
 
     let expected_tokens = vec![

--- a/crates/parser/tests/storage_pointer_derivation.rs
+++ b/crates/parser/tests/storage_pointer_derivation.rs
@@ -8,7 +8,7 @@ fn derives_storage_pointers() {
         "#define constant FSP_LOCATION = FREE_STORAGE_POINTER()\n#define constant FSP_LOCATION_2 = FREE_STORAGE_POINTER()\n#define constant NUM = 0xa57B";
 
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source.source, None);
+    let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
     let mut contract = parser.parse().unwrap();

--- a/crates/parser/tests/table.rs
+++ b/crates/parser/tests/table.rs
@@ -9,7 +9,7 @@ fn table_with_no_body() {
     for kind in table_kinds {
         let source = &format!("#define {kind} TEST_TABLE() = {}{}", "{", "}");
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
 
         let mut parser = Parser::new(tokens, None);
@@ -52,7 +52,7 @@ fn table_with_body() {
         let lb3_start = source.find("label_call_3").unwrap_or(0);
         let flattened_source = FullFileSource { source, file: None, spans: vec![] };
 
-        let lexer = Lexer::new(flattened_source.source, None);
+        let lexer = Lexer::new(flattened_source);
         let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
 
         let mut parser = Parser::new(tokens, None);

--- a/crates/utils/src/token.rs
+++ b/crates/utils/src/token.rs
@@ -143,6 +143,11 @@ impl TokenKind {
     pub fn into_span(self, start: u32, end: u32, file: Option<Arc<FileSource>>) -> Token {
         Token { kind: self, span: Span { start: start as usize, end: end as usize, file } }
     }
+
+    /// Transform a TokenKind into a Token given a Span
+    pub fn into_token_with_span(self, span: Span) -> Token {
+        Token { kind: self, span }
+    }
 }
 
 impl fmt::Display for TokenKind {


### PR DESCRIPTION
The files are flatted before lexing. To mach now error message to code position this need to be resolved. This was already there but got broken in 012789c. 