### PR TITLE
Add error for duplicate macro labels  (Original author is 0xrusowsky)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,7 @@ name = "huff-neo-lexer"
 version = "0.0.2"
 dependencies = [
  "huff-neo-utils",
+ "lazy_static",
  "regex",
  "tracing",
 ]

--- a/crates/codegen/README.md
+++ b/crates/codegen/README.md
@@ -94,6 +94,7 @@ let contract = Contract {
   functions: vec![],
   events: vec![],
   tables: vec![],
+  labels: HashSet::new(),
 };
 
 // Generate the main bytecode
@@ -149,6 +150,7 @@ let contract = Contract {
   functions: vec![],
   events: vec![],
   tables: vec![],
+  labels: HashSet::new(),
 };
 
 // Generate the constructor bytecode

--- a/crates/codegen/tests/abigen.rs
+++ b/crates/codegen/tests/abigen.rs
@@ -1,10 +1,10 @@
+use huff_neo_codegen::Codegen;
+use huff_neo_utils::prelude::*;
+use std::collections::HashSet;
 use std::{
     collections::BTreeMap,
     sync::{Arc, Mutex},
 };
-
-use huff_neo_codegen::Codegen;
-use huff_neo_utils::prelude::*;
 
 #[test]
 fn constructs_valid_abi() {
@@ -28,6 +28,7 @@ fn constructs_valid_abi() {
         functions: vec![],
         events: vec![],
         tables: vec![],
+        labels: HashSet::new(),
     };
 
     // Generate the abi from the contract
@@ -68,6 +69,7 @@ fn missing_constructor_fails() {
         functions: vec![],
         events: vec![],
         tables: vec![],
+        labels: HashSet::new(),
     };
 
     // Generate the abi from the contract

--- a/crates/lexer/Cargo.toml
+++ b/crates/lexer/Cargo.toml
@@ -12,5 +12,7 @@ keywords = ["bytecode", "compiler", "evm", "huff", "rust"]
 
 [dependencies]
 huff-neo-utils.workspace = true
+
+lazy_static.workspace = true
 regex.workspace = true
 tracing.workspace = true

--- a/crates/parser/README.md
+++ b/crates/parser/README.md
@@ -58,6 +58,7 @@ let expected_contract = Contract {
   functions: vec![],
   events: vec![],
   tables: vec![],
+  labels: HashSet::new(),
 };
 assert_eq!(unwrapped_contract.macros, expected_contract.macros);
 ```

--- a/crates/parser/tests/labels.rs
+++ b/crates/parser/tests/labels.rs
@@ -1,6 +1,6 @@
 use huff_neo_lexer::*;
 use huff_neo_parser::*;
-use huff_neo_utils::{evm::Opcode, prelude::*};
+use huff_neo_utils::{error::ParserErrorKind, evm::Opcode, prelude::*};
 
 #[test]
 fn multiline_labels() {
@@ -381,4 +381,26 @@ pub fn builtins_under_labels() {
         assert_eq!(s.ty, md_expected.statements[i].ty);
         assert_eq!(s.span, md_expected.statements[i].span);
     }
+}
+
+#[test]
+fn duplicated_labels() {
+    let source = r#"
+    #define macro MAIN() = takes(0) returns(0) {
+        cool_label jump
+        cool_label jump
+        cool_label: 0x00
+        dup_label: 0x00
+        dup_label: 0x00
+    }
+    "#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Grab the first macro
+    let parse_result = parser.parse();
+    assert!(parse_result.is_err());
+    assert_eq!(parse_result.unwrap_err().kind, ParserErrorKind::DuplicateLabel("dup_label".to_string()));
 }

--- a/crates/utils/src/ast.rs
+++ b/crates/utils/src/ast.rs
@@ -10,6 +10,7 @@ use crate::{
     evm_version::EVMVersion,
     prelude::{MacroArg::Ident, Span, TokenKind},
 };
+use std::collections::HashSet;
 use std::{
     collections::BTreeMap,
     fmt::{Display, Formatter},
@@ -112,6 +113,8 @@ pub struct Contract {
     pub events: Vec<EventDefinition>,
     /// Tables
     pub tables: Vec<TableDefinition>,
+    /// Labels
+    pub labels: HashSet<String>,
 }
 
 impl Contract {

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -65,6 +65,8 @@ pub enum ParserErrorKind {
     InvalidDecoratorFlag(String),
     /// Invalid decorator flag argument
     InvalidDecoratorFlagArg(TokenKind),
+    /// Duplicate label
+    DuplicateLabel(String),
     /// Duplicate MACRO
     DuplicateMacro(String),
 }
@@ -412,6 +414,9 @@ impl fmt::Display for CompilerError {
                         dfa,
                         pe.spans.error(pe.hint.as_ref())
                     )
+                }
+                ParserErrorKind::DuplicateLabel(label) => {
+                    write!(f, "\nError: Duplicate label: \"{}\" \n{}\n", label, pe.spans.error(pe.hint.as_ref()))
                 }
                 ParserErrorKind::DuplicateMacro(mn) => {
                     write!(f, "\nError: Duplicate MACRO name found: \"{}\" \n{}\n", mn, pe.spans.error(pe.hint.as_ref()))

--- a/crates/utils/src/files.rs
+++ b/crates/utils/src/files.rs
@@ -343,6 +343,12 @@ impl Span {
                 f.source
                     .as_ref()
                     .map(|s| {
+                        if self.start >= s.len() {
+                            return "\nInternal compiler error: Start index out of range".to_string();
+                        }
+                        if self.end >= s.len() {
+                            return "\nInternal compiler error: End index out of range: file".to_string();
+                        }
                         let line_num = &s[0..self.start].as_bytes().iter().filter(|&&c| c == b'\n').count() + 1;
                         let line_start = &s[0..self.start].rfind('\n').unwrap_or(0);
                         let line_end = self.end + s[self.end..s.len()].find('\n').unwrap_or(s.len() - self.end).to_owned();


### PR DESCRIPTION
Reviving https://github.com/huff-language/huff-rs/pull/308 and add check for duplicate macro labels in macro bodies. This is a very basic implementation that can have more edge cases e.g. functions, macros with same name, etc. But for most users this should help enough. Thanks @0xrusowsky for adding this to huff-rs.