### PR TITLE
Introduce new builtin `__BYTES()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # Huff Neo Compiler changelog
 
 ## [Unreleased]
+- Add built-in macros for converting a string to bytes and push it to the stack.
+  - `__BYTES("hello")` -> `PUSH5 0x68656c6c6f`
+  - This can also be used here: `__RIGHTPAD(__BYTES("hello"))`.
 
 ## [1.0.6] - 2025-01-28
 - Allow to use `--debug` for reverting contracts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Huff Neo Compiler changelog
 
 ## [Unreleased]
+
+## [1.0.7] - 2025-01-29
 - Add built-in macros for converting a string to bytes and push it to the stack.
   - `__BYTES("hello")` -> `PUSH5 0x68656c6c6f`
   - This can also be used here: `__RIGHTPAD(__BYTES("hello"))`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "hnc"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -3714,7 +3714,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "huff-neo-codegen"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-core"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-js"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "huff-neo-core",
  "huff-neo-utils",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-lexer"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "huff-neo-utils",
  "lazy_static",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-parser"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-test-runner"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "alloy-primitives",
  "anvil",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-utils"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/cakevm/huff-neo"
 rust-version = "1.84"
-version = "1.0.6"
+version = "1.0.7"
 
 [workspace.dependencies]
 huff-neo-codegen = { path = "crates/codegen" }

--- a/crates/codegen/src/irgen/arg_calls.rs
+++ b/crates/codegen/src/irgen/arg_calls.rs
@@ -31,9 +31,9 @@ pub fn bubble_arg_call(
                 tracing::info!(target: "codegen", "GOT \"{:?}\" ARG FROM MACRO INVOCATION", arg);
                 match arg {
                     MacroArg::Literal(l) => {
-                        tracing::info!(target: "codegen", "GOT LITERAL {} ARG FROM MACRO INVOCATION", bytes32_to_string(l, false));
+                        tracing::info!(target: "codegen", "GOT LITERAL {} ARG FROM MACRO INVOCATION", bytes32_to_hex_string(l, false));
 
-                        let hex_literal: String = bytes32_to_string(l, false);
+                        let hex_literal: String = bytes32_to_hex_string(l, false);
                         let push_bytes = format!("{:02x}{hex_literal}", 95 + hex_literal.len() / 2);
                         let b = Bytes(push_bytes);
                         *offset += b.0.len() / 2;
@@ -91,7 +91,7 @@ pub fn bubble_arg_call(
                             tracing::info!(target: "codegen", "ARGCALL IS CONSTANT: {:?}", constant);
                             let push_bytes = match &constant.value {
                                 ConstVal::Literal(l) => {
-                                    let hex_literal: String = bytes32_to_string(l, false);
+                                    let hex_literal: String = bytes32_to_hex_string(l, false);
                                     format!("{:02x}{hex_literal}", 95 + hex_literal.len() / 2)
                                 }
                                 ConstVal::FreeStoragePointer(fsp) => {

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -144,7 +144,7 @@ impl Codegen {
 
         res.utilized_tables.iter().try_for_each(|jt| {
             table_offsets.insert(jt.name.to_string(), table_offset);
-            let size = match bytes_util::hex_to_usize(bytes_util::bytes32_to_string(&jt.size, false).as_str()) {
+            let size = match bytes_util::hex_to_usize(bytes_util::bytes32_to_hex_string(&jt.size, false).as_str()) {
                 Ok(s) => s,
                 Err(e) => {
                     tracing::error!(target: "codegen", "Errored converting bytes32 to str. Bytes {:?} with error: {:?}", jt.size, e);

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -10,7 +10,7 @@ use huff_neo_utils::ast::span::AstSpan;
 use huff_neo_utils::file::remapper;
 use huff_neo_utils::{
     error::*,
-    prelude::{bytes32_to_string, str_to_bytes32, Span},
+    prelude::{bytes32_to_hex_string, str_to_bytes32, Span},
     token::{Token, TokenKind},
     types::*,
 };
@@ -75,12 +75,12 @@ impl Parser {
                 tracing::info!(target: "parser", "SUCCESSFULLY PARSED MACRO {}", m.name);
                 contract.macros.push(m);
             }
-            // Check for a defition with the "#define" keyword
+            // Check for a definition with the "#define" keyword
             else if self.check(TokenKind::Define) {
                 // Consume the definition token
                 self.match_kind(TokenKind::Define)?;
 
-                // match to fucntion, constant, macro, or event
+                // match to function, constant, macro, or event
                 match self.current_token.kind {
                     TokenKind::Function => {
                         let func = self.parse_function()?;
@@ -589,7 +589,7 @@ impl Parser {
                                 self.consume();
 
                                 // Check that the literal does not overflow the push size
-                                let hex_literal: String = bytes32_to_string(&val, false);
+                                let hex_literal: String = bytes32_to_hex_string(&val, false);
                                 if o.push_overflows(&hex_literal) {
                                     return Err(ParserError {
                                         kind: ParserErrorKind::InvalidPush(o),
@@ -823,7 +823,7 @@ impl Parser {
             if let TokenKind::Literal(l) = &self.current_token.kind {
                 args.push(BuiltinFunctionArg::Argument(Argument {
                     // Place literal in the "name" field
-                    name: Some(bytes32_to_string(l, false)),
+                    name: Some(bytes32_to_hex_string(l, false)),
                     arg_location: None,
                     arg_type: None,
                     indexed: false,

--- a/crates/utils/src/ast/huff.rs
+++ b/crates/utils/src/ast/huff.rs
@@ -380,7 +380,7 @@ impl MacroDefinition {
                     if o.is_value_push() {
                         match statement_iter.next() {
                             Some(Statement { ty: StatementType::Literal(l), span: _ }) => {
-                                let hex_literal: String = bytes32_to_string(l, false);
+                                let hex_literal: String = bytes32_to_hex_string(l, false);
                                 let prefixed_hex_literal = o.prefix_push_literal(&hex_literal);
                                 inner_irbytes.push(IRBytes { ty: IRByteType::Bytes(Bytes(prefixed_hex_literal)), span: &statement.span });
                             }
@@ -575,6 +575,8 @@ pub enum BuiltinFunctionKind {
     DynConstructorArg,
     /// Inject Raw Bytes
     Verbatim,
+    /// Bytes function to convert a string to bytes
+    Bytes,
 }
 
 impl From<String> for BuiltinFunctionKind {
@@ -589,6 +591,7 @@ impl From<String> for BuiltinFunctionKind {
             "__RIGHTPAD" => BuiltinFunctionKind::RightPad,
             "__CODECOPY_DYN_ARG" => BuiltinFunctionKind::DynConstructorArg,
             "__VERBATIM" => BuiltinFunctionKind::Verbatim,
+            "__BYTES" => BuiltinFunctionKind::Bytes,
             _ => panic!("Invalid Builtin Function Kind"), /* This should never be reached,
                                                            * builtins are validated with a
                                                            * `try_from` call in the lexer. */
@@ -610,6 +613,7 @@ impl TryFrom<&String> for BuiltinFunctionKind {
             "__RIGHTPAD" => Ok(BuiltinFunctionKind::RightPad),
             "__CODECOPY_DYN_ARG" => Ok(BuiltinFunctionKind::DynConstructorArg),
             "__VERBATIM" => Ok(BuiltinFunctionKind::Verbatim),
+            "__BYTES" => Ok(BuiltinFunctionKind::Bytes),
             _ => Err(()),
         }
     }
@@ -650,7 +654,7 @@ pub enum StatementType {
 impl Display for StatementType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            StatementType::Literal(l) => write!(f, "LITERAL: {}", bytes32_to_string(l, true)),
+            StatementType::Literal(l) => write!(f, "LITERAL: {}", bytes32_to_hex_string(l, true)),
             StatementType::Opcode(o) => write!(f, "OPCODE: {o}"),
             StatementType::Code(s) => write!(f, "CODE: {s}"),
             StatementType::MacroInvocation(m) => {

--- a/crates/utils/src/bytes_util.rs
+++ b/crates/utils/src/bytes_util.rs
@@ -1,5 +1,4 @@
 use crate::{evm_version::EVMVersion, opcodes::Opcode};
-use alloy_primitives::hex;
 use std::num::ParseIntError;
 
 /// Convert a string slice to a `[u8; 32]`
@@ -21,7 +20,7 @@ pub fn str_to_bytes32(s: &str) -> [u8; 32] {
 }
 
 /// Convert a `[u8; 32]` to a bytes string.
-pub fn bytes32_to_string(bytes: &[u8; 32], prefixed: bool) -> String {
+pub fn bytes32_to_hex_string(bytes: &[u8; 32], prefixed: bool) -> String {
     let mut s = String::default();
     let start = bytes.iter().position(|b| *b != 0).unwrap_or(bytes.len() - 1);
     for b in &bytes[start..bytes.len()] {
@@ -62,7 +61,7 @@ pub fn str_to_vec(s: &str) -> Result<Vec<u8>, std::num::ParseIntError> {
 
 /// Converts a value literal to its smallest equivalent `PUSHX` bytecode. Leading zeros are removed.
 pub fn literal_gen(evm_version: &EVMVersion, l: &[u8; 32]) -> String {
-    let hex_literal: String = bytes32_to_string(l, false);
+    let hex_literal: String = bytes32_to_hex_string(l, false);
     match hex_literal.as_str() {
         "00" => format_push0(evm_version, hex_literal),
         _ => format_literal(hex_literal),
@@ -80,9 +79,4 @@ fn format_push0(evm_version: &EVMVersion, hex_literal: String) -> String {
 /// Converts a literal into its bytecode string representation
 pub fn format_literal(hex_literal: String) -> String {
     format!("{:02x}{hex_literal}", 95 + hex_literal.len() / 2)
-}
-
-/// Convert a slice of bytes to an u32
-pub fn bytes_to_u32(b: &[u8]) -> u32 {
-    u32::from_str_radix(hex::encode(b).as_str(), 16).unwrap_or(0)
 }

--- a/crates/utils/tests/byte_utils.rs
+++ b/crates/utils/tests/byte_utils.rs
@@ -1,4 +1,4 @@
-use huff_neo_utils::bytes_util::{bytes32_to_string, literal_gen, str_to_bytes32};
+use huff_neo_utils::bytes_util::{bytes32_to_hex_string, literal_gen, str_to_bytes32};
 use huff_neo_utils::evm_version::{EVMVersion, SupportedEVMVersions};
 
 #[test]
@@ -6,7 +6,7 @@ fn test_converts_literal_to_hex_string() {
     let sources = ["00", "01", "1000", "010101", "a57b", "8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"];
 
     for source in sources {
-        assert_eq!(format!("0x{source}"), bytes32_to_string(&str_to_bytes32(source), true));
+        assert_eq!(format!("0x{source}"), bytes32_to_hex_string(&str_to_bytes32(source), true));
     }
 }
 

--- a/crates/utils/tests/bytes.rs
+++ b/crates/utils/tests/bytes.rs
@@ -3,7 +3,7 @@ use huff_neo_utils::bytes_util::*;
 #[test]
 fn test_bytes32_to_string() {
     let byte_arr: [u8; 32] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254];
-    let converted_string = bytes32_to_string(&byte_arr, false);
+    let converted_string = bytes32_to_hex_string(&byte_arr, false);
     assert_eq!(converted_string, "fe");
 }
 


### PR DESCRIPTION
- Add built-in macros for converting a string to bytes and push it to the stack.
  - `__BYTES("hello")` -> `PUSH5 0x68656c6c6f`
  - This can also be used here: `__RIGHTPAD(__BYTES("hello"))`.