### PR TITLE
Pass constant as parameter for builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - Introduce new lexer token type `Bytes`, as not all hex should be parsed to bytes32.
   - For constants in code tables the bytes are copied as defined with e.g. leading zeros.
   - For all other cases leading zeros are removed and the smallest push operation is used.
+- New built-in function `__LEFTPAD` to a hex input or a function result in a code table.
+  - The function can only be used in a code table.
+  - Example: `__LEFTPAD(0x123)` -> `0000000000000000000000000000000000000000000000000000000000000123`
+- Allow to pass a constant as a parameter to `__RIGHTPAD` or `__LEFTPAD`.
+  - Example: `__RIGHTPAD([CONST])`
 
 ## [1.0.10] - 2025-01-31
 - Add windows binary to the release.

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -3,7 +3,7 @@
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]
 
-use crate::irgen::builtin_function::{builtin_bytes, function_signature, right_pad};
+use crate::irgen::builtin_function::{builtin_bytes, builtin_pad, function_signature, PadDirection};
 use alloy_primitives::hex;
 use huff_neo_utils::ast::huff::*;
 use huff_neo_utils::ast::span::AstSpan;
@@ -163,7 +163,11 @@ impl Codegen {
                         byte_code = format!("{byte_code}{}", &bytes[2..]);
                     }
                     BuiltinFunctionKind::RightPad => {
-                        let bytes = right_pad(evm_version, contract, &bf)?;
+                        let bytes = builtin_pad(evm_version, contract, &bf, PadDirection::Right)?;
+                        byte_code = format!("{byte_code}{}", &bytes[2..]);
+                    }
+                    BuiltinFunctionKind::LeftPad => {
+                        let bytes = builtin_pad(evm_version, contract, &bf, PadDirection::Left)?;
                         byte_code = format!("{byte_code}{}", &bytes[2..]);
                     }
                     BuiltinFunctionKind::Bytes => {

--- a/crates/core/tests/code_table.rs
+++ b/crates/core/tests/code_table.rs
@@ -123,6 +123,44 @@ fn test_code_table_constant() {
 }
 
 #[test]
+fn test_code_table_leftpad() {
+    let source: &str = r#"
+        #define table CODE_TABLE() {
+            __LEFTPAD(0x0123)
+        }
+
+        #define macro MAIN() = takes(0) returns (0) {
+            __tablesize(CODE_TABLE)
+            __tablestart(CODE_TABLE)
+        }
+    "#;
+
+    // Parse tokens
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Parse the AST
+    let mut contract = parser.parse().unwrap();
+
+    // Derive storage pointers
+    contract.derive_storage_pointers();
+
+    // Instantiate Codegen
+    let cg = Codegen::new();
+
+    // The codegen instance should have no artifact
+    assert!(cg.artifact.is_none());
+
+    // Have the Codegen create the constructor bytecode
+    let mbytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
+
+    // 60 = PUSH1, 20 = 32 bytes table size, 61 = PUSH2, 0005 = 5 bytes table start
+    assert_eq!(mbytes, "60 20 61 0005 0000000000000000000000000000000000000000000000000000000000000123".replace(" ", ""));
+}
+
+#[test]
 fn test_code_table_constant_with_leading_zeros() {
     let source: &str = r#"
         #define constant ADDR = 0x00000001
@@ -207,6 +245,8 @@ fn test_code_table_all_features() {
             __RIGHTPAD(__FUNC_SIG("transfer(address,uint256)"))
             0xDEADBEEF
             [ADDR]
+            __LEFTPAD(0x123)
+            __LEFTPAD([ADDR])
         }
 
         #define macro MAIN() = takes(0) returns (0) {
@@ -236,10 +276,13 @@ fn test_code_table_all_features() {
     // Have the Codegen create the constructor bytecode
     let mbytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
 
-    // 60 = PUSH1, 36 = 56 bytes table size (32 + 4 + 20), 61 = PUSH2, 0005 = 5 bytes table start, a9059cbb = transfer(address,uint256)
+    // 60 = PUSH1, 78 = 120 bytes table size (32 + 4 + 20), 61 = PUSH2, 0005 = 5 bytes table start, a9059cbb = transfer(address,uint256)
     assert_eq!(
         mbytes,
-        "60 38 61 0005 a9059cbb00000000000000000000000000000000000000000000000000000000 deadbeef 0101010101010101010101010101010101010101"
+        "60 78 61 0005 a9059cbb00000000000000000000000000000000000000000000000000000000 deadbeef \
+        0101010101010101010101010101010101010101 \
+        0000000000000000000000000000000000000000000000000000000000000123\
+        0000000000000000000000000101010101010101010101010101010101010101"
             .replace(" ", "")
     );
 }

--- a/crates/utils/src/ast/huff.rs
+++ b/crates/utils/src/ast/huff.rs
@@ -533,6 +533,8 @@ pub enum BuiltinFunctionArg {
     BuiltinFunctionCall(BuiltinFunctionCall),
     /// Abi Argument
     Argument(Argument),
+    /// Constant Argument
+    Constant(String, AstSpan),
 }
 
 impl BuiltinFunctionArg {
@@ -542,6 +544,7 @@ impl BuiltinFunctionArg {
             BuiltinFunctionArg::Literal(_) => AstSpan::default(),
             BuiltinFunctionArg::BuiltinFunctionCall(b) => b.span.clone(),
             BuiltinFunctionArg::Argument(a) => a.span.clone(),
+            BuiltinFunctionArg::Constant(_, span) => span.clone(),
         }
     }
 }
@@ -577,6 +580,8 @@ pub enum BuiltinFunctionKind {
     Error,
     /// Rightpad function
     RightPad,
+    /// Leftpad function (only available in code tables)
+    LeftPad,
     /// Dynamic constructor arg function
     DynConstructorArg,
     /// Inject Raw Bytes
@@ -595,6 +600,7 @@ impl From<String> for BuiltinFunctionKind {
             "__EVENT_HASH" => BuiltinFunctionKind::EventHash,
             "__ERROR" => BuiltinFunctionKind::Error,
             "__RIGHTPAD" => BuiltinFunctionKind::RightPad,
+            "__LEFTPAD" => BuiltinFunctionKind::LeftPad,
             "__CODECOPY_DYN_ARG" => BuiltinFunctionKind::DynConstructorArg,
             "__VERBATIM" => BuiltinFunctionKind::Verbatim,
             "__BYTES" => BuiltinFunctionKind::Bytes,
@@ -617,6 +623,7 @@ impl TryFrom<&String> for BuiltinFunctionKind {
             "__EVENT_HASH" => Ok(BuiltinFunctionKind::EventHash),
             "__ERROR" => Ok(BuiltinFunctionKind::Error),
             "__RIGHTPAD" => Ok(BuiltinFunctionKind::RightPad),
+            "__LEFTPAD" => Ok(BuiltinFunctionKind::LeftPad),
             "__CODECOPY_DYN_ARG" => Ok(BuiltinFunctionKind::DynConstructorArg),
             "__VERBATIM" => Ok(BuiltinFunctionKind::Verbatim),
             "__BYTES" => Ok(BuiltinFunctionKind::Bytes),
@@ -635,6 +642,7 @@ impl Display for BuiltinFunctionKind {
             BuiltinFunctionKind::EventHash => write!(f, "__EVENT_HASH"),
             BuiltinFunctionKind::Error => write!(f, "__ERROR"),
             BuiltinFunctionKind::RightPad => write!(f, "__RIGHTPAD"),
+            BuiltinFunctionKind::LeftPad => write!(f, "__LEFTPAD"),
             BuiltinFunctionKind::DynConstructorArg => write!(f, "__CODECOPY_DYN_ARG"),
             BuiltinFunctionKind::Verbatim => write!(f, "__VERBATIM"),
             BuiltinFunctionKind::Bytes => write!(f, "__BYTES"),


### PR DESCRIPTION
- New built-in function `__LEFTPAD` to a hex input or a function result in a code table.
  - The function can only be used in a code table.
  - Example: `__LEFTPAD(0x123)` -> `0000000000000000000000000000000000000000000000000000000000000123`
- Allow to pass a constant as a parameter to `__RIGHTPAD` or `__LEFTPAD`.
  - Example: `__RIGHTPAD([CONST])`