### PR TITLE
Allow to use built-in functions in constant assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,25 @@
 # Huff Neo Compiler changelog
 
 ## [Unreleased]
+
+## [1.1.0] - 2025-02-02
 - Support for constants in code tables.
-- Use correct code line for error messages in code tables for builtins.
+- Use correct code line for error messages in code tables for built-ins.
 - Switch to Foundry's print function for trace logs.
-- Allow to use `--target-address` to specify the contract address during a test.
+- Allow using `--target-address` to specify the contract address during a test.
 - Disable base fee check for tests.
 - Allow uneven bytes for code tables e.g. `0x1` is valid and results in `0x01` bytecode.
 - Introduce new lexer token type `Bytes`, as not all hex should be parsed to bytes32.
-  - For constants in code tables the bytes are copied as defined with e.g. leading zeros.
-  - For all other cases leading zeros are removed and the smallest push operation is used.
-- New built-in function `__LEFTPAD` to a hex input or a function result in a code table.
+  - For constants in code tables, the bytes are copied as defined with e.g. leading zeros.
+  - For all other cases, leading zeros are removed and the smallest push operation is used.
+- New built-in function `__LEFTPAD` to a pad a hex input or a function result in a code table to the left in 32 bytes.
   - The function can only be used in a code table.
   - Example: `__LEFTPAD(0x123)` -> `0000000000000000000000000000000000000000000000000000000000000123`
 - Allow to pass a constant as a parameter to `__RIGHTPAD` or `__LEFTPAD`.
   - Example: `__RIGHTPAD([CONST])`
+- Allow to use built-in functions in constant assignment.
+  - Example: `#define constant FUNC_TEST = __FUNC_SIG("test(uint256)")`
+  - This solves the issue to define functions with the same name but different arguments.
 
 ## [1.0.10] - 2025-01-31
 - Add windows binary to the release.

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
-- [Getting Started](get-started/overview.md)
-  - [Installation](get-started/installation.md)
+- [Getting Started](get-started/getting-started.md)
+  - [About Huff](get-started/about-huff.md)
+  - [Comparison to huffc](get-started/comparison-to-huffc.md)
   - [Compile a contract](get-started/compiling.md)
   - [Project Quickstart](get-started/project-quickstart.md)
 - [Huff Language](huff-language/overview.md)

--- a/book/get-started/about-huff.md
+++ b/book/get-started/about-huff.md
@@ -1,15 +1,10 @@
-# Getting started
+# About Huff
 
 Huff is a low-level programming language designed for developing highly optimized smart contracts that run on the Ethereum Virtual Machine (EVM). Huff does not hide the inner workings of the EVM and instead exposes its programming stack to the developer for manual manipulation.
 
 While EVM experts can use Huff to write highly-efficient smart contracts for use in production, it can also serve as a way for beginners to learn more about the EVM.
 
 If you're looking for an in-depth guide on how to write and understand Huff, check out the [tutorials](../tutorial/overview.md).
-
-## There is `huff-rs` and `huff-neo`?
-
-Yes, there are two versions of the Huff compiler. The original compiler, `huff-rs` is no longer maintained. There is a plan to revive it as [huff2](https://github.com/huff-language/huff2), but since it is a new development from scratch, it is unknown when it will have feature parity with the original compiler. `huff-neo` tries to step-in and continues the development and also tries to evolve the Huff language where necessary.
-
 
 ## History of the Huff Language
 The [Aztec Protocol](https://aztec.network/) team originally created Huff to write [Weierstrudel](https://github.com/aztecprotocol/weierstrudel/tree/master/huff_modules), an on-chain elliptical curve arithmetic library that requires incredibly optimized code that neither [Solidity](https://docs.soliditylang.org/) nor [Yul](https://docs.soliditylang.org/en/latest/yul.html) could provide.

--- a/book/get-started/comparison-to-huffc.md
+++ b/book/get-started/comparison-to-huffc.md
@@ -1,0 +1,42 @@
+# Comparison to huffc
+The goal of `huff-neo` is to keep the same syntax as `huffc` but to be more efficient and to have a better error handling. There are some additions to the language but the syntax should be backwards compatible.
+
+## There is `huff-rs` and `huff-neo`?
+
+Yes, there are two versions of the Huff compiler. The original compiler, `huff-rs` is no longer maintained. There is a plan to revive it as [huff2](https://github.com/huff-language/huff2), but since it is a new development from scratch, it is unknown when it will have feature parity with the original compiler. `huff-neo` tries to step-in and continues the development and also tries to evolve the Huff language where necessary.
+
+## New in `huff-neo`
+There are some new features in `huff-neo` that are not available in `huffc`.
+
+### Allowed use of built-in functions for constants and code tables
+The usage of built-in functions for constants and code tables is now possible.
+
+```javascript
+#define constant FUNC_TEST = __FUNC_SIG("test(uint256)")
+#define constant BYTES_HELLO = __BYTES("hello")
+
+#define code_table TEST_TABLE {
+    0x123
+    __FUNC_SIG("test(uint256)")
+    __BYTES("hello")
+    __LEFTPAD(__FUNC_SIG("test(uint256)")) // New built-in function __LEFTPAD
+    [FUNC_TEST]
+    [BYTES_HELLO]
+}
+```
+
+### New built-in functions
+There are new built-in functions available in `huff-neo`.
+
+- `__LEFTPAD` - Left pads a hex input or the result of a passed built-in in a code table.
+- `__BYTES` - Converts a string to the UTF-8 representation bytes and pushes it to the stack.
+
+```javascript
+#define macro MAIN() = takes (0) returns (0) {
+    __BYTES("hello") // Will push UTF-8 encoded string (PUSH5 0x68656c6c6f)
+}
+```
+
+### New test capabilities
+The test module has been refactored to use `anvil` and `forge` features from `foundry` to fork the mainnet. This allows for more advanced testing capabilities.
+

--- a/book/get-started/getting-started.md
+++ b/book/get-started/getting-started.md
@@ -16,8 +16,9 @@ Now, with `hnc-up` installed and in your path, you can simply run `hnc-up` to in
 
 ### On Windows, build from the source
 
-If you use Windows, you need to build from the source to get huff.
+If you use Windows, you can build from the source or download the binary form the [releases](https://github.com/cakevm/huff-neo/releases) to get huff.
 
+#### Building from the source
 Download and run `rustup-init` from [rustup.rs](https://win.rustup.rs/x86_64). It will start the installation in a console.
 
 If you encounter an error, it is most likely the case that you do not have the VS Code Installer which you can [download here](https://visualstudio.microsoft.com/downloads/) and install.

--- a/book/huff-language/builtin-functions.md
+++ b/book/huff-language/builtin-functions.md
@@ -12,8 +12,25 @@ At compile time, the invocation of `__EVENT_HASH` is substituted with `PUSH32 ev
 ### `__ERROR(<error definition>)`
 At compile time, the invocation of `__ERROR` is substituted with `PUSH32 error_selector`, where `error_selector` is the left-padded 4 byte error selector of the passed error definition.
 
+### `__LEFTPAD(<string>|<hex>|<builtin function>)`
+At compile time, the invocation of `__LEFTPAD` is substituted with `padded_literal`, where `padded_literal` is the left padded version of the passed input. This function is only available as constant assignment or in a code table.
+
+#### Example
+```plaintext
+__LEFTPAD(0x123)
+// will result in 32 bytes:
+0x0000000000000000000000000000000000000000000000000000000000000123
+```
+
 ### `__RIGHTPAD(<string>|<hex>|<builtin function>)`
 At compile time, the invocation of `__RIGHTPAD` is substituted with `PUSH32 padded_literal`, where `padded_literal` is the right padded version of the passed input.
+
+#### Example
+```plaintext
+__RIGHTPAD(0x123)
+// will result in 32 bytes:
+0x1230000000000000000000000000000000000000000000000000000000000000
+```
 
 ### `__codesize(<macro>|<function>)`
 Pushes the code size of the macro or function passed to the stack.
@@ -26,6 +43,13 @@ This function is used to insert raw hex data into the compiled bytecode. It is u
 
 ### `__BYTES(<string>)`
 This function allows to insert a string as UTF-8 encoded bytes into the compiled bytecode. The resulting bytecode is limited to 32 bytes.
+
+#### Example
+```javascript
+#define macro MAIN() = takes (0) returns (0) {
+    __BYTES("hello") // Will push UTF-8 encoded string (PUSH5 0x68656c6c6f)
+}
+```
 
 ## Combining Builtin Functions
 Some builtin functions can be combined with other functions. Possible combinations are:

--- a/book/huff-language/code-table.md
+++ b/book/huff-language/code-table.md
@@ -5,16 +5,38 @@ them at the end of the runtime bytecode, assuming they are referenced
 somewhere within the contract.
 
 ## Example
+
+### Define a code table
 ```javascript
 #define table CODE_TABLE {
     0x604260005260206000F3
 }
+
+#define macro MAIN() = takes (0) returns (0) {
+    
+    // Copy the code table into memory at 0x00
+    __tablesize(CODE_TABLE)   // size
+    __tablestart(CODE_TABLE)  // offset
+    0x00                      // destOffset
+    codecopy
+}
 ```
 
-Usage of a builtin function inside a code table:
+### Usage of a builtin function
 ```javascript
 #define table CODE_TABLE {
     __RIGHTPAD(__FUNC_SIG("test(address, uint256)"))
     0x604260005260206000F3
 }
 ```
+
+### Usage of a constant reference
+```javascript
+#define constant CONST = 0x123
+
+#define table CODE_TABLE {
+    [CONST]
+    __LEFTPAD([CONST])
+}
+```
+

--- a/book/huff-language/constants.md
+++ b/book/huff-language/constants.md
@@ -2,7 +2,7 @@
 
 Constants in Huff contracts are not included in the contract's storage; Instead,
 they are able to be called within the contract at compile time. Constants
-can either be bytes (32 max) or a `FREE_STORAGE_POINTER`. A `FREE_STORAGE_POINTER`
+can either be bytes (32 max), `FREE_STORAGE_POINTER` or a built-in function. A `FREE_STORAGE_POINTER`
 constant will always represent an unused storage slot in the contract.
 
 In order to push a constant to the stack, use bracket notation: `[CONSTANT]`
@@ -14,6 +14,7 @@ In order to push a constant to the stack, use bracket notation: `[CONSTANT]`
 #define constant NUM = 0x420
 #define constant HELLO_WORLD = 0x48656c6c6f2c20576f726c6421
 #define constant FREE_STORAGE = FREE_STORAGE_POINTER()
+#define constant TEST = __FUNC_SIG("test(uint256)")
 ```
 
 **Constant Usage**

--- a/book/tutorial/the-basics.md
+++ b/book/tutorial/the-basics.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Before you get started writing Huff you will have to install the compiler. Head over to [Getting Started](../get-started/overview.md) and follow the steps to get it installed.
+Before you get started writing Huff you will have to install the compiler. Head over to [Getting Started](../get-started/getting-started.md) and follow the steps to get it installed.
 Once complete - come back here!!
 
 ## What you are going to learn?

--- a/crates/codegen/src/irgen/constants.rs
+++ b/crates/codegen/src/irgen/constants.rs
@@ -1,3 +1,4 @@
+use crate::Codegen;
 use huff_neo_utils::ast::span::AstSpan;
 use huff_neo_utils::prelude::{
     literal_gen, str_to_bytes32, CodegenError, CodegenErrorKind, ConstVal, ConstantDefinition, Contract, EVMVersion,
@@ -17,6 +18,7 @@ pub fn constant_gen(evm_version: &EVMVersion, name: &str, contract: &Contract, i
             literal_gen(evm_version, &hex_literal)
         }
         ConstVal::StoragePointer(sp) => literal_gen(evm_version, sp),
+        ConstVal::BuiltinFunctionCall(bf) => Codegen::gen_builtin_bytecode(evm_version, contract, bf, ir_byte_span.clone())?,
         ConstVal::FreeStoragePointer(fsp) => {
             // If this is reached in codegen stage, the `derive_storage_pointers`
             // method was not called on the AST.

--- a/crates/core/tests/constants.rs
+++ b/crates/core/tests/constants.rs
@@ -1,0 +1,40 @@
+use huff_neo_codegen::Codegen;
+use huff_neo_lexer::Lexer;
+use huff_neo_parser::Parser;
+use huff_neo_utils::evm_version::EVMVersion;
+use huff_neo_utils::file::full_file_source::FullFileSource;
+use huff_neo_utils::prelude::Token;
+
+#[test]
+fn test_builtin_rightpad_bytes() {
+    let source: &str = r#"
+        #define constant FUNC = __FUNC_SIG("transfer(address,uint256)")
+
+        #define macro MAIN() = takes (0) returns (0) {
+            [FUNC]
+        }
+    "#;
+
+    // Parse tokens
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Parse the AST
+    let mut contract = parser.parse().unwrap();
+
+    // Derive storage pointers
+    contract.derive_storage_pointers();
+
+    // Instantiate Codegen
+    let cg = Codegen::new();
+
+    // The codegen instance should have no artifact
+    assert!(cg.artifact.is_none());
+
+    // Have Codegen create the runtime bytecode
+    let r_bytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
+    // PUSH4 = 0x63, `transfer(address,uint256) signature = 0xa9059cbb
+    assert_eq!(&r_bytes, "63a9059cbb");
+}

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -319,7 +319,8 @@ impl<'a> Lexer<'a> {
                         kind
                     } else if (self.context == Context::MacroBody
                         || self.context == Context::BuiltinFunction
-                        || self.context == Context::CodeTableBody)
+                        || self.context == Context::CodeTableBody
+                        || self.context == Context::Constant)
                         && BuiltinFunctionKind::try_from(&word).is_ok()
                     {
                         TokenKind::BuiltinFunction(word)

--- a/crates/lexer/tests/constant.rs
+++ b/crates/lexer/tests/constant.rs
@@ -60,3 +60,20 @@ fn constant_leading_zeros_hex_literal() {
     assert_eq!(tokens[3].kind, TokenKind::Assign);
     assert_eq!(tokens[4].kind, TokenKind::Bytes("000000000000000000000000000000000000000000000000000000010203".to_string()));
 }
+
+#[test]
+fn constant_builtin() {
+    let source = "#define constant TEST = __FUNC_SIG('hello()')";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).filter(|x| !matches!(x.kind, TokenKind::Whitespace)).collect::<Vec<Token>>();
+
+    assert_eq!(tokens[0].kind, TokenKind::Define);
+    assert_eq!(tokens[1].kind, TokenKind::Constant);
+    assert_eq!(tokens[2].kind, TokenKind::Ident("TEST".to_string()));
+    assert_eq!(tokens[3].kind, TokenKind::Assign);
+    assert_eq!(tokens[4].kind, TokenKind::BuiltinFunction("__FUNC_SIG".to_string()));
+    assert_eq!(tokens[5].kind, TokenKind::OpenParen);
+    assert_eq!(tokens[6].kind, TokenKind::Str("hello()".to_string()));
+    assert_eq!(tokens[7].kind, TokenKind::CloseParen);
+}

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -383,6 +383,12 @@ impl Parser {
                 self.consume();
                 ConstVal::Bytes(Bytes(l))
             }
+            TokenKind::BuiltinFunction(f) => {
+                let curr_spans = vec![self.current_token.span.clone()];
+                self.match_kind(TokenKind::BuiltinFunction(String::default()))?;
+                let args = self.parse_builtin_args()?;
+                ConstVal::BuiltinFunctionCall(BuiltinFunctionCall { kind: BuiltinFunctionKind::from(f), args, span: AstSpan(curr_spans) })
+            }
             kind => {
                 tracing::error!(target: "parser", "TOKEN MISMATCH - EXPECTED FreeStoragePointer OR Hex, GOT: {}", self.current_token.kind);
                 return Err(ParserError {

--- a/crates/parser/tests/constant.rs
+++ b/crates/parser/tests/constant.rs
@@ -1,5 +1,6 @@
 use huff_neo_lexer::*;
 use huff_neo_parser::*;
+use huff_neo_utils::ast::abi::Argument;
 use huff_neo_utils::ast::span::AstSpan;
 use huff_neo_utils::file::full_file_source::FullFileSource;
 use huff_neo_utils::prelude::*;
@@ -54,6 +55,47 @@ fn test_parses_literal_constant() {
                 Span { start: 17, end: 23, file: None },
                 Span { start: 25, end: 25, file: None },
                 Span { start: 29, end: 92, file: None }
+            ])
+        }
+    );
+}
+
+#[test]
+fn test_parses_func_sign_constant() {
+    let source = "#define constant FUNC = __FUNC_SIG('hello()')";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+    // Check Literal
+    let fsp_constant = contract.constants.lock().unwrap()[0].clone();
+    assert_eq!(
+        fsp_constant,
+        ConstantDefinition {
+            name: "FUNC".to_string(),
+            value: ConstVal::BuiltinFunctionCall(BuiltinFunctionCall {
+                kind: BuiltinFunctionKind::FunctionSignature,
+                args: vec![BuiltinFunctionArg::Argument(Argument {
+                    arg_type: None,
+                    arg_location: None,
+                    name: Some("hello()".to_string()),
+                    indexed: false,
+                    span: AstSpan(vec![Span { start: 35, end: 43, file: None }])
+                })],
+                span: AstSpan(vec![Span { start: 24, end: 33, file: None }]),
+            }),
+            span: AstSpan(vec![
+                Span { start: 0, end: 6, file: None },
+                Span { start: 8, end: 15, file: None },
+                Span { start: 17, end: 20, file: None },
+                Span { start: 22, end: 22, file: None },
+                Span { start: 24, end: 33, file: None },
+                Span { start: 34, end: 34, file: None },
+                Span { start: 35, end: 43, file: None },
+                Span { start: 44, end: 44, file: None }
             ])
         }
     );

--- a/crates/utils/src/ast/huff.rs
+++ b/crates/utils/src/ast/huff.rs
@@ -235,7 +235,7 @@ impl Contract {
                             let new_value = str_to_bytes32(&format!("{old_p}"));
                             storage_pointers.push((const_name.to_string(), new_value));
                         }
-                        ConstVal::Bytes(_) => {
+                        ConstVal::Bytes(_) | ConstVal::BuiltinFunctionCall(_) => {
                             // Skip constants that are not free storage pointers
                         }
                         // This should never be reached, as we only assign free storage pointers
@@ -487,6 +487,8 @@ pub enum ConstVal {
     FreeStoragePointer(FreeStoragePointer),
     /// A Storage Pointer assigned by the compiler
     StoragePointer(Literal),
+    /// Built-in function call
+    BuiltinFunctionCall(BuiltinFunctionCall),
 }
 
 /// A Constant Definition
@@ -531,6 +533,7 @@ pub enum BuiltinFunctionArg {
     Literal(Literal),
     /// Builtin Function Call
     BuiltinFunctionCall(BuiltinFunctionCall),
+    // TODO: Remove this and replace with a better type
     /// Abi Argument
     Argument(Argument),
     /// Constant Argument


### PR DESCRIPTION
- Allow to use built-in functions in constant assignment.
  - Example: `#define constant FUNC_TEST = __FUNC_SIG("test(uint256)")`
  - This solves the issue to define functions with the same name but different arguments.