### PR TITLE
Remove all build args that have been imported from Foundry without effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 # Huff Neo Compiler changelog
 
 ## [Unreleased]
-- Update to latest `revm` and `foundry` version.
+
+## [1.1.2] - 2025-02-06
+- Update to the latest `revm` and `foundry` versions.
+- Remove parameters without effect from `test` that have been added by Foundry.
 
 ## [1.1.1] - 2025-02-02
 - Update dependencies to the latest version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,8 +765,8 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.2.0",
- "rustls 0.23.22",
+ "http",
+ "rustls",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.26.1",
@@ -875,7 +875,7 @@ dependencies = [
 [[package]]
 name = "anvil"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -913,7 +913,7 @@ dependencies = [
  "foundry-config",
  "foundry-evm",
  "futures",
- "hyper 1.6.0",
+ "hyper",
  "itertools 0.14.0",
  "k256",
  "op-alloy-consensus",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "anvil-core"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "anvil-rpc"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "serde",
  "serde_json",
@@ -970,7 +970,7 @@ dependencies = [
 [[package]]
 name = "anvil-server"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "anvil-rpc",
  "async-trait",
@@ -1237,209 +1237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "aws-credential-types"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "zeroize",
-]
-
-[[package]]
-name = "aws-runtime"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee7643696e7fdd74c10f9eb42848a87fe469d35eae9c3323f80aa98f350baac"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
- "uuid 1.12.1",
-]
-
-[[package]]
-name = "aws-sdk-kms"
-version = "1.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b7a24700ac548025a47a5c579886f5198895bb1eccd8964dfd71cd66c16912"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "1.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690118821e46967b3c4501d67d7d52dd75106a9c54cf36cefa1985cedbe94e05"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "form_urlencoded",
- "hex",
- "hmac",
- "http 0.2.12",
- "http 1.2.0",
- "once_cell",
- "percent-encoding",
- "sha2",
- "time",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa59d1327d8b5053c54bf2eaae63bf629ba9e904434d0835a28ed3c0ed0a614e"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.60.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623a51127f24c30776c8b374295f2df78d92517386f77ba30773f15a30ce1422"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "1.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865f7050bbc7107a6c98a397a9fcd9413690c27fa718446967cf03b2d3ac517e"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "httparse",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "rustls 0.21.12",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "http 1.2.0",
- "pin-project-lite",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "1.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f6feb647fb5e0d5b50f0472c19a7db9462b74e2fec01bb0b44eedcc834e97"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "http 0.2.12",
- "http 1.2.0",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
-]
-
-[[package]]
-name = "aws-types"
-version = "1.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0df5a18c4f951c645300d365fec53a61418bcf4650f604f85fe2a665bfaa0c2"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "rustc_version 0.4.1",
- "tracing",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,10 +1247,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1485,8 +1282,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1529,16 +1326,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
 
 [[package]]
 name = "base64ct"
@@ -1675,21 +1462,11 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bytes-utils"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
-dependencies = [
- "bytes",
- "either",
 ]
 
 [[package]]
@@ -1730,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "jobserver",
  "libc",
@@ -1802,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1846,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2060,16 +1837,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2615,7 +2382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2755,7 +2522,7 @@ checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 [[package]]
 name = "forge-fmt"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-primitives",
  "ariadne",
@@ -2769,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "forge-script-sequence"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -2815,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "foundry-cheatcodes"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -2863,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "foundry-cheatcodes-spec"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-sol-types",
  "foundry-macros",
@@ -2873,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "foundry-cli"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
@@ -2911,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "foundry-common"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -2963,7 +2730,7 @@ dependencies = [
 [[package]]
 name = "foundry-common-fmt"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -2981,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203e96bd596350ec8d9aedfca7eff573e9347e2b2fe50eedfbf78532dabe418e"
+checksum = "de23802550de5204eec1a6297296d2fef6b86ea61f33b1667eebd886577caa34"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3015,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8ba2ccf8a4bf7730b2ad2815984c1af8e5b8c492420f1cf1d26a8be29cc9e4"
+checksum = "27f065a1c785b3ec556a7a49a27016fc723bd9a4d8623f521c326f8396df64a6"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -3025,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-solc"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5889eeb7d6729afbbbb1313b22e8f58aa909fcf38aa6b2f9c9b2443ca0765c59"
+checksum = "127e0e788765bc0103eb6b92067843c6ffe660090b2f6fbff1a1441a51939aa0"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3049,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01048f354b4e98bf5fb4810e0607c87d4b8cc7fe6305a42103ce192e33b2da7"
+checksum = "8764f450332267305440ec399560919e01aa98f23af2c36ac952f9216449cdca"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3064,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-core"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079b80a4f188af9c273b081547d1a95a0a33f782851a99e21aa4eba06e47fa34"
+checksum = "c59caebbeaeb0e34564c1a404081478a0aadaa8999b57f0befd85965252e074a"
 dependencies = [
  "alloy-primitives",
  "cfg-if",
@@ -3085,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "foundry-config"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "Inflector",
  "alloy-chains",
@@ -3121,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "foundry-debugger"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-primitives",
  "crossterm",
@@ -3140,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3168,7 +2935,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm-abi"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3181,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm-core"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -3215,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm-coverage"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3231,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm-fuzz"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3256,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm-traces"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3308,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "foundry-linking"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-primitives",
  "foundry-compilers",
@@ -3319,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "foundry-macros"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -3330,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=aee9f47#aee9f47eabea0a79409f3b802f53aa14fba7a4a8"
+source = "git+https://github.com/foundry-rs/foundry?rev=c4ae688#c4ae68826405e2ecb4ab4c27cbce5ac4e21bf1a3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -3342,7 +3109,6 @@ dependencies = [
  "alloy-signer-trezor",
  "alloy-sol-types",
  "async-trait",
- "aws-sdk-kms",
  "clap",
  "derive_builder",
  "eth-keystore",
@@ -3553,25 +3319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "hnc"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -3667,10 +3414,11 @@ dependencies = [
  "huff-neo-core",
  "huff-neo-test-runner",
  "huff-neo-utils",
+ "serde",
  "shadow-rs",
  "tokio",
  "tracing",
- "uuid 1.12.1",
+ "uuid 1.13.1",
  "yansi",
 ]
 
@@ -3681,17 +3429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
 ]
 
 [[package]]
@@ -3707,23 +3444,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http",
 ]
 
 [[package]]
@@ -3734,8 +3460,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -3753,7 +3479,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "huff-neo-codegen"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -3761,12 +3487,12 @@ dependencies = [
  "regex",
  "serde_json",
  "tracing",
- "uuid 1.12.1",
+ "uuid 1.13.1",
 ]
 
 [[package]]
 name = "huff-neo-core"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -3781,13 +3507,13 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
- "uuid 1.12.1",
+ "uuid 1.13.1",
  "walkdir",
 ]
 
 [[package]]
 name = "huff-neo-js"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "huff-neo-core",
  "huff-neo-utils",
@@ -3798,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-lexer"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "huff-neo-utils",
  "lazy_static",
@@ -3808,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-parser"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "alloy-primitives",
  "hex",
@@ -3820,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-test-runner"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "alloy-primitives",
  "anvil",
@@ -3844,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-utils"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -3861,31 +3587,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "uuid 1.12.1",
-]
-
-[[package]]
-name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
+ "uuid 1.13.1",
 ]
 
 [[package]]
@@ -3897,8 +3599,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -3910,35 +3612,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.6.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.22",
- "rustls-native-certs 0.8.1",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots",
 ]
@@ -3952,9 +3638,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -4250,7 +3936,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4855,9 +4541,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e8e67b41afd338096ca31f24c5e7800797858b963490be2e8971d17d733f49"
+checksum = "1363dd2454f473e2a2a6ee5eda585ecf94209319e35529bd703ddc5072798eb4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4880,12 +4566,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "overload"
@@ -5114,18 +4794,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5380,7 +5060,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.22",
+ "rustls",
  "socket2",
  "thiserror 2.0.11",
  "tokio",
@@ -5398,7 +5078,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash",
- "rustls 0.23.22",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.11",
@@ -5418,7 +5098,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5456,7 +5136,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.0",
- "zerocopy 0.8.14",
+ "zerocopy 0.8.16",
 ]
 
 [[package]]
@@ -5495,7 +5175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.14",
+ "zerocopy 0.8.16",
 ]
 
 [[package]]
@@ -5618,12 +5298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5646,11 +5320,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -5660,16 +5334,16 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.22",
- "rustls-native-certs 0.8.1",
- "rustls-pemfile 2.2.0",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls",
  "tokio-socks",
  "tower",
  "tower-service",
@@ -5881,9 +5555,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -5922,19 +5596,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5946,21 +5608,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -5972,16 +5622,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
+ "security-framework",
 ]
 
 [[package]]
@@ -6000,16 +5641,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -6067,9 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.3.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e1c91382686d21b5ac7959341fcb9780fa7c03773646995a87c950fa7be640"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
 dependencies = [
  "sdd",
 ]
@@ -6108,20 +5739,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "sdd"
-version = "3.0.5"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "sec1"
@@ -6158,25 +5779,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.8.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation 0.10.0",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6797,7 +6405,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7008,21 +6616,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.22",
+ "rustls",
  "tokio",
 ]
 
@@ -7070,10 +6668,10 @@ checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.22",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls",
  "tungstenite 0.26.1",
  "webpki-roots",
 ]
@@ -7093,9 +6691,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "indexmap",
  "serde",
@@ -7150,8 +6748,8 @@ checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "bitflags 2.8.0",
  "bytes",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -7271,7 +6869,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.2.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -7289,11 +6887,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.2.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.22",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.11",
@@ -7474,11 +7072,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -7512,16 +7110,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -7702,7 +7294,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7900,9 +7492,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
 dependencies = [
  "memchr",
 ]
@@ -8001,11 +7593,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+checksum = "7b8c07a70861ce02bad1607b5753ecb2501f67847b9f9ada7c160fff0ec6300c"
 dependencies = [
- "zerocopy-derive 0.8.14",
+ "zerocopy-derive 0.8.16",
 ]
 
 [[package]]
@@ -8021,9 +7613,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
+checksum = "5226bc9a9a9836e7428936cde76bb6b22feea1a8bfdbc0d241136e4d13417e25"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/cakevm/huff-neo"
 rust-version = "1.84"
-version = "1.1.1"
+version = "1.1.2"
 
 [workspace.dependencies]
 huff-neo-codegen = { path = "crates/codegen" }
@@ -23,17 +23,17 @@ huff-neo-utils = { path = "crates/utils" }
 
 alloy-dyn-abi = "0.8.20"
 alloy-primitives = "0.8.20"
-anvil = { package = "anvil", git = "https://github.com/foundry-rs/foundry", rev = "aee9f47" }
+anvil = { package = "anvil", git = "https://github.com/foundry-rs/foundry", rev = "c4ae688" }
 cfg-if = "1.0.0"
-clap = { version = "4.5.27", features = ["derive"] }
+clap = { version = "4.5.28", features = ["derive"] }
 comfy-table = "7.1.3"
 eyre = "0.6.12"
-foundry-cli = { package = "foundry-cli", git = "https://github.com/foundry-rs/foundry", rev = "aee9f47" }
-foundry-common = { package = "foundry-common", git = "https://github.com/foundry-rs/foundry", rev = "aee9f47" }
-foundry-config = { package = "foundry-config", git = "https://github.com/foundry-rs/foundry", rev = "aee9f47" }
-foundry-debugger = { package = "foundry-debugger", git = "https://github.com/foundry-rs/foundry", rev = "aee9f47" }
-foundry-evm = { package = "foundry-evm", git = "https://github.com/foundry-rs/foundry", rev = "aee9f47" }
-foundry-evm-traces = { package = "foundry-evm-traces", git = "https://github.com/foundry-rs/foundry", rev = "aee9f47" }
+foundry-cli = { git = "https://github.com/foundry-rs/foundry", rev = "c4ae688" }
+foundry-common = { git = "https://github.com/foundry-rs/foundry", rev = "c4ae688" }
+foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "c4ae688" }
+foundry-debugger = { git = "https://github.com/foundry-rs/foundry", rev = "c4ae688" }
+foundry-evm = { git = "https://github.com/foundry-rs/foundry", rev = "c4ae688" }
+foundry-evm-traces = { git = "https://github.com/foundry-rs/foundry", rev = "c4ae688" }
 hex = "0.4.3"
 itertools = "0.14.0"
 js-sys = { version = "0.3.77" }
@@ -48,7 +48,7 @@ thiserror = "2.0.11"
 tokio = "1.43.0"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", default-features = false, features = ["env-filter", "fmt"] }
-uuid = { version = "1.12.1", features = ["v4"] }
+uuid = { version = "1.13.1", features = ["v4"] }
 walkdir = "2.5.0"
 wasm-bindgen = "0.2"
 yansi = "1.0.1"
@@ -61,7 +61,7 @@ serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.138"
 strum = "0.26.3"
 strum_macros = "0.26.4"
-toml = "0.8.19"
+toml = "0.8.20"
 
 # dev
 criterion = "0.5.1"

--- a/bin/hnc/Cargo.toml
+++ b/bin/hnc/Cargo.toml
@@ -25,6 +25,7 @@ foundry-cli.workspace = true
 foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm-traces.workspace = true
+serde.workspace = true
 shadow-rs.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/bin/hnc/src/arguments/base.rs
+++ b/bin/hnc/src/arguments/base.rs
@@ -1,13 +1,7 @@
-use alloy_primitives::Address;
-use clap::{ArgAction, Parser, Subcommand};
-use foundry_cli::opts::BuildOpts;
-use foundry_common::evm::EvmArgs;
-use foundry_config::figment::value::{Dict, Map};
-use foundry_config::figment::{Metadata, Profile, Provider};
-use foundry_config::{figment, Config};
+use crate::arguments::test::TestArgs;
+use clap::{Parser, Subcommand};
 use huff_neo_utils::error::CompilerError;
 use huff_neo_utils::file::unpack_files::unpack_files;
-use huff_neo_utils::shell::Verbosity;
 use std::io::Write;
 use std::path::Path;
 use yansi::Paint;
@@ -94,89 +88,6 @@ pub struct HuffArgs {
     /// Print version
     #[arg(short = 'V', long = "version")]
     pub version_long: bool,
-}
-
-// Loads project's figment and merges the build cli arguments into it
-foundry_config::merge_impl_figment_convert!(TestArgs, build, evm);
-
-/// The Test CLI Args
-#[derive(Parser, Debug, Clone)]
-pub struct TestArgs {
-    /// Format the test output as a list, table, or JSON.
-    #[clap(long = "format")]
-    pub format: Option<String>,
-
-    /// Match a specific test
-    #[clap(short = 'm', long = "match")]
-    pub match_: Option<String>,
-
-    /// Target address for the contract
-    #[arg(long)]
-    pub target_address: Option<Address>,
-
-    // All those options are taken from https://github.com/foundry-rs/foundry
-    /// Verbosity level
-    #[arg(help_heading = "Display options", global = true, short, long, verbatim_doc_comment, action = ArgAction::Count)]
-    pub verbosity: Verbosity,
-
-    /// Run a single test in the debugger.
-    ///
-    /// The matching test will be opened in the debugger regardless of the outcome of the test.
-    ///
-    /// If the matching test is a fuzz test, then it will open the debugger on the first failure
-    /// case. If the fuzz test does not fail, it will open the debugger on the last fuzz case.
-    #[arg(long, conflicts_with_all = ["flamegraph", "flamechart", "decode_internal", "rerun"])]
-    pub debug: bool,
-
-    /// Generate a flamegraph for a single test. Implies `--decode-internal`.
-    ///
-    /// A flame graph is used to visualize which functions or operations within the smart contract
-    /// are consuming the most gas overall in a sorted manner.
-    #[arg(long)]
-    flamegraph: bool,
-
-    /// Generate a flamechart for a single test. Implies `--decode-internal`.
-    ///
-    /// A flame chart shows the gas usage over time, illustrating when each function is
-    /// called (execution order) and how much gas it consumes at each point in the timeline.
-    #[arg(long, conflicts_with = "flamegraph")]
-    flamechart: bool,
-
-    /// Identify internal functions in traces.
-    ///
-    /// This will trace internal functions and decode stack parameters.
-    ///
-    /// Parameters stored in memory (such as bytes or arrays) are currently decoded only when a
-    /// single function is matched, similarly to `--debug`, for performance reasons.
-    #[arg(long)]
-    pub decode_internal: bool,
-
-    /// Print a gas report.
-    #[arg(long, env = "FORGE_GAS_REPORT")]
-    pub gas_report: bool,
-
-    /// Anvil node parameters
-    #[command(flatten)]
-    pub evm: EvmArgs,
-
-    // required for figment
-    #[command(flatten)]
-    pub build: BuildOpts,
-
-    /// Re-run recorded test failures from last run.
-    /// If no failure recorded then regular test run is performed.
-    #[arg(long)]
-    pub rerun: bool,
-}
-
-impl Provider for TestArgs {
-    fn metadata(&self) -> Metadata {
-        Metadata::named("TestArgs Provider")
-    }
-
-    fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
-        Ok(Map::from([(Config::selected_profile(), Dict::default())]))
-    }
 }
 
 #[derive(Subcommand, Clone, Debug)]

--- a/bin/hnc/src/arguments/evm.rs
+++ b/bin/hnc/src/arguments/evm.rs
@@ -1,0 +1,98 @@
+use alloy_primitives::private::serde::Serialize;
+use alloy_primitives::Address;
+use clap::Parser;
+use foundry_common::evm::EnvArgs;
+use foundry_config::figment::error::Kind::InvalidType;
+use foundry_config::figment::value::{Dict, Map, Value};
+use foundry_config::figment::{Figment, Metadata, Profile, Provider};
+use foundry_config::{figment, Config};
+
+// Adapted/Copy from https://github.com/foundry-rs/foundry/blob/1d5fa64/crates/common/src/evm.rs#L46
+
+#[derive(Clone, Debug, Default, Serialize, Parser)]
+#[command(next_help_heading = "EVM options", about = None, long_about = None)] // override doc
+pub struct EvmArgs {
+    /// Fetch state over a remote endpoint instead of starting from an empty state.
+    ///
+    /// If you want to fetch state from a specific block number, see --fork-block-number.
+    #[arg(long, short, visible_alias = "rpc-url", value_name = "URL")]
+    #[serde(rename = "eth_rpc_url", skip_serializing_if = "Option::is_none")]
+    pub fork_url: Option<String>,
+
+    /// Fetch state from a specific block number over a remote endpoint.
+    ///
+    /// See --fork-url.
+    #[arg(long, requires = "fork_url", value_name = "BLOCK")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fork_block_number: Option<u64>,
+
+    /// Number of retries.
+    ///
+    /// See --fork-url.
+    #[arg(long, requires = "fork_url", value_name = "RETRIES")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fork_retries: Option<u32>,
+
+    /// Initial retry backoff on encountering errors.
+    ///
+    /// See --fork-url.
+    #[arg(long, requires = "fork_url", value_name = "BACKOFF")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fork_retry_backoff: Option<u64>,
+
+    /// Explicitly disables the use of RPC caching.
+    ///
+    /// All storage slots are read entirely from the endpoint.
+    ///
+    /// This flag overrides the project's configuration file.
+    ///
+    /// See --fork-url.
+    #[arg(long)]
+    #[serde(skip)]
+    pub no_storage_caching: bool,
+
+    /// The address which will be executing tests/scripts.
+    #[arg(long, value_name = "ADDRESS")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender: Option<Address>,
+
+    /// Sets the number of assumed available compute units per second for this provider
+    ///
+    /// default value: 330
+    ///
+    /// See also --fork-url and <https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second>
+    #[arg(long, alias = "cups", value_name = "CUPS", help_heading = "Fork config")]
+    pub compute_units_per_second: Option<u64>,
+
+    /// Disables rate limiting for this node's provider.
+    ///
+    /// See also --fork-url and <https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second>
+    #[arg(long, value_name = "NO_RATE_LIMITS", help_heading = "Fork config", visible_alias = "no-rate-limit")]
+    #[serde(skip)]
+    pub no_rpc_rate_limit: bool,
+
+    /// All ethereum environment related arguments
+    #[command(flatten)]
+    #[serde(flatten)]
+    pub env: EnvArgs,
+}
+
+impl Provider for EvmArgs {
+    fn metadata(&self) -> Metadata {
+        Metadata::named("Evm Opts Provider")
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
+        let value = Value::serialize(self)?;
+        let error = InvalidType(value.to_actual(), "map".into());
+        let dict = value.into_dict().ok_or(error)?;
+
+        Ok(Map::from([(Config::selected_profile(), dict)]))
+    }
+}
+
+impl From<&EvmArgs> for Figment {
+    fn from(value: &EvmArgs) -> Self {
+        Config::figment().merge(value)
+    }
+}

--- a/bin/hnc/src/arguments/mod.rs
+++ b/bin/hnc/src/arguments/mod.rs
@@ -1,0 +1,3 @@
+pub mod base;
+mod evm;
+pub mod test;

--- a/bin/hnc/src/arguments/test.rs
+++ b/bin/hnc/src/arguments/test.rs
@@ -1,0 +1,61 @@
+use crate::arguments::evm::EvmArgs;
+use alloy_primitives::Address;
+use clap::ArgAction;
+use clap::Parser;
+use foundry_config::figment::value::{Dict, Map};
+use foundry_config::figment::{Metadata, Profile, Provider};
+use foundry_config::{figment, Config};
+use huff_neo_utils::shell::Verbosity;
+
+foundry_config::merge_impl_figment_convert!(TestArgs, evm);
+
+/// The Test CLI Args
+#[derive(Parser, Debug, Clone)]
+pub struct TestArgs {
+    /// Format the test output as a list, table, or JSON.
+    #[clap(long = "format")]
+    pub format: Option<String>,
+
+    /// Match a specific test by name.
+    #[clap(short = 'm', long = "match")]
+    pub match_: Option<String>,
+
+    /// Target address for the contract
+    #[arg(long)]
+    pub target_address: Option<Address>,
+
+    /// Verbosity level
+    #[arg(help_heading = "Display options", global = true, short, long, verbatim_doc_comment, action = ArgAction::Count)]
+    pub verbosity: Verbosity,
+
+    /// Run a single test in the debugger. The matching test will be opened in the debugger regardless of the outcome of the test.
+    #[arg(long)]
+    pub debug: bool,
+
+    /// Identify internal functions in traces.
+    ///
+    /// This will trace internal functions and decode stack parameters.
+    ///
+    /// Parameters stored in memory (such as bytes or arrays) are currently decoded only when a
+    /// single function is matched, similarly to `--debug`, for performance reasons.
+    #[arg(long)]
+    pub decode_internal: bool,
+
+    /// Print a gas report.
+    #[arg(long, env = "FORGE_GAS_REPORT")]
+    pub gas_report: bool,
+
+    /// Anvil node parameters
+    #[command(flatten)]
+    pub evm: EvmArgs,
+}
+
+impl Provider for TestArgs {
+    fn metadata(&self) -> Metadata {
+        Metadata::named("TestArgs Provider")
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
+        Ok(Map::from([(Config::selected_profile(), Dict::default())]))
+    }
+}

--- a/crates/test-runner/src/lib.rs
+++ b/crates/test-runner/src/lib.rs
@@ -1,7 +1,6 @@
 use crate::{errors::RunnerError, runner::TestRunner, types::TestResult};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use huff_neo_utils::prelude::{Contract, MacroDefinition};
-use std::{borrow::Borrow, rc::Rc};
 
 /// The runner module
 pub mod runner;
@@ -38,22 +37,16 @@ pub struct HuffTesterConfig {
     /// The address which will be used to deploy the initial contracts and send all
     /// transactions
     pub sender: Option<Address>,
-    /// The initial balance for each one of the deployed smart contracts
-    pub initial_balance: U256,
     /// The EVM spec to use
     pub evm_spec: Option<SpecId>,
     /// The fork to use at launch
     pub fork: Option<CreateFork>,
-    /// Whether or not to collect coverage info
-    pub coverage: bool,
-    /// Whether or not to collect debug info
+    /// Whether to collect debug info
     pub debug: bool,
     /// Whether to enable steps tracking in the tracer.
     pub decode_internal: InternalTraceMode,
     /// Whether to enable call isolation
     pub isolation: bool,
-    /// Whether to enable Odyssey features.
-    pub odyssey: bool,
     /// The target address for the contract
     pub target_address: Option<Address>,
 }
@@ -68,11 +61,6 @@ impl HuffTesterConfig {
         self
     }
 
-    pub fn initial_balance(mut self, initial_balance: U256) -> Self {
-        self.initial_balance = initial_balance;
-        self
-    }
-
     pub fn evm_spec(mut self, spec: SpecId) -> Self {
         self.evm_spec = Some(spec);
         self
@@ -80,11 +68,6 @@ impl HuffTesterConfig {
 
     pub fn with_fork(mut self, fork: Option<CreateFork>) -> Self {
         self.fork = fork;
-        self
-    }
-
-    pub fn set_coverage(mut self, enable: bool) -> Self {
-        self.coverage = enable;
         self
     }
 
@@ -100,11 +83,6 @@ impl HuffTesterConfig {
 
     pub fn enable_isolation(mut self, enable: bool) -> Self {
         self.isolation = enable;
-        self
-    }
-
-    pub fn odyssey(mut self, enable: bool) -> Self {
-        self.odyssey = enable;
         self
     }
 
@@ -136,7 +114,7 @@ pub struct HuffTester<'t> {
 /// HuffTester implementation
 impl<'t> HuffTester<'t> {
     /// Create a new instance of `HuffTester` from a contract's AST.
-    pub fn new(ast: &'t Contract, match_: Rc<Option<String>>, inspectors: Inspector, config: HuffTesterConfig, env: Env) -> Self {
+    pub fn new(ast: &'t Contract, match_test_name: Option<String>, inspectors: Inspector, config: HuffTesterConfig, env: Env) -> Self {
         Self {
             ast,
             macros: {
@@ -144,8 +122,8 @@ impl<'t> HuffTester<'t> {
                 let mut macros: TestMacros<'t> = ast.macros.iter().filter(|m| m.test).collect();
                 // If the match flag is present, only retain the test macro
                 // that was queried
-                if let Some(match_) = match_.borrow() {
-                    macros.retain(|m| m.name == *match_);
+                if let Some(match_test_name) = match_test_name {
+                    macros.retain(|m| m.name == *match_test_name);
                 }
                 macros
             },


### PR DESCRIPTION
- Update to latest `revm` and `foundry` version.
- Remove parameters without effect from `test`, that have been added from Foundry.