### PR TITLE
feat: Nested macro calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 # Huff Neo Compiler changelog
 
 ## [Unreleased]
-- Add feature that allows to pass a macro call as a parameter to another macro.
-  - Example: `MACRO1(MACRO2(0x1, 0x2), 0x3)`.
+- Support nesting of macro calls e.g. `MACRO1(MACRO2(0x1, 0x2), 0x3)`. (See: #40)
+  - Thank you very much to @Mouradif for the contribution!
 
 ## [1.1.4] - 2025-03-17
 - Update dependencies to the latest version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Huff Neo Compiler changelog
 
 ## [Unreleased]
+- Add feature that allows to pass a macro call as a parameter to another macro.
+  - Example: `MACRO1(MACRO2(0x1, 0x2), 0x3)`.
 
 ## [1.1.4] - 2025-03-17
 - Update dependencies to the latest version.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ getrandom = { version = "0.3.1", features = ["wasm_js"] }
 rayon = "1.10.0"
 
 [profile.test]
-debug = 1
+debug = "full"
 incremental = true
 
 [profile.release]

--- a/book/huff-language/macros-and-functions.md
+++ b/book/huff-language/macros-and-functions.md
@@ -39,7 +39,7 @@ by the constructor.
 
 ### Macro Arguments
 
-Macros can accept arguments to be "called" inside the macro or passed as a reference. Macro arguments may be one of: label, opcode, literal, or a constant. Since macros are inlined at compile-time, the arguments are not evaluated at runtime and are instead inlined as well.
+Macros can accept arguments, which can be used within the macro itself or passed as reference. These arguments can be labels, opcodes, literals, constants, or other macro calls. Since macros are inlined at compile time, their arguments are also inlined and not evaluated at runtime.
 
 #### Example
 
@@ -137,7 +137,7 @@ your contract, and it is essentially a trade-off of decreasing contract size
 for a small extra runtime gas cost (`22 + n_inputs * 3 + n_outputs * 3` gas
 per invocation, to be exact).
 
-Functions are one of the only high-level abstractions
+Functions are one of the few high-level abstractions
 in Huff, so it is important to understand what the compiler adds to your code
 when they are utilized. It is not always beneficial to re-use code, especially
 if it is a small / inexpensive set of operations. However, for larger contracts

--- a/crates/codegen/src/irgen/arg_calls.rs
+++ b/crates/codegen/src/irgen/arg_calls.rs
@@ -162,6 +162,12 @@ pub fn bubble_arg_call(
                                     return Err(e);
                                 }
                             }
+                        } else {
+                            return Err(CodegenError {
+                                kind: CodegenErrorKind::MissingMacroDefinition(inner_mi.macro_name.clone()),
+                                span: inner_mi.span.clone(),
+                                token: None,
+                            });
                         }
                     }
                 }

--- a/crates/utils/src/ast/huff.rs
+++ b/crates/utils/src/ast/huff.rs
@@ -472,6 +472,8 @@ pub enum MacroArg {
     Ident(String),
     /// An Arg Call
     ArgCall(String),
+    /// A Nested Macro Call
+    MacroCall(MacroInvocation),
 }
 
 /// Free Storage Pointer Unit Struct


### PR DESCRIPTION
Allow passing macro calls as macro call arguments. The expression passed can be used in the target macro and the compiler will expand it to its expected bytecode.