### PR TITLE
Disallow the use of the same name for a macro, test or fn (Fixes: #53).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 - Throw an error if an argument (e.g. `<arg>`) is used but not defined (Fixes: #46).
+- Disallow the use of the same name for a macro, test or fn (Fixes: #53).
 
 ## [1.1.5] - 2025-03-19
 - Support nesting of macro calls e.g. `MACRO1(MACRO2(0x1, 0x2), 0x3)`. (See: #40)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 [[package]]
 name = "anvil"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -911,7 +911,6 @@ dependencies = [
  "anvil-server",
  "async-trait",
  "axum",
- "bytes",
  "chrono",
  "clap",
  "clap_complete",
@@ -927,19 +926,16 @@ dependencies = [
  "futures",
  "hyper",
  "itertools 0.14.0",
- "k256",
  "op-alloy-consensus",
  "parking_lot",
  "rand 0.8.5",
  "revm",
  "serde",
  "serde_json",
- "serde_repr",
  "tempfile",
  "thiserror 2.0.12",
  "tikv-jemallocator",
  "tokio",
- "tower",
  "tracing",
  "tracing-subscriber",
  "yansi",
@@ -948,7 +944,7 @@ dependencies = [
 [[package]]
 name = "anvil-core"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -973,7 +969,7 @@ dependencies = [
 [[package]]
 name = "anvil-rpc"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "serde",
  "serde_json",
@@ -982,7 +978,7 @@ dependencies = [
 [[package]]
 name = "anvil-server"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "anvil-rpc",
  "async-trait",
@@ -2549,7 +2545,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "forge-fmt"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-primitives",
  "ariadne",
@@ -2563,11 +2559,10 @@ dependencies = [
 [[package]]
 name = "forge-script-sequence"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
- "alloy-rpc-types",
  "eyre",
  "foundry-common",
  "foundry-compilers",
@@ -2575,7 +2570,6 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tracing",
  "walkdir",
 ]
 
@@ -2609,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "foundry-cheatcodes"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -2657,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "foundry-cheatcodes-spec"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-sol-types",
  "foundry-macros",
@@ -2667,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "foundry-cli"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
@@ -2705,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "foundry-common"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -2757,7 +2751,7 @@ dependencies = [
 [[package]]
 name = "foundry-common-fmt"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -2879,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "foundry-config"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "Inflector",
  "alloy-chains",
@@ -2915,7 +2909,7 @@ dependencies = [
 [[package]]
 name = "foundry-debugger"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-primitives",
  "crossterm",
@@ -2934,7 +2928,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -2962,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm-abi"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2975,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm-core"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -3009,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm-coverage"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3025,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm-fuzz"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3050,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "foundry-evm-traces"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3101,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "foundry-linking"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-primitives",
  "foundry-compilers",
@@ -3112,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "foundry-macros"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -3123,7 +3117,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "1.0.0"
-source = "git+https://github.com/foundry-rs/foundry?rev=a7e3421#a7e3421c6e0101b1e6494b3b2ac770dcfdadab5f"
+source = "git+https://github.com/foundry-rs/foundry?rev=967a89e#967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -3516,6 +3510,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
  "huff-neo-utils",
+ "indexmap 2.8.0",
  "regex",
  "serde_json",
  "tracing",
@@ -3572,6 +3567,7 @@ dependencies = [
  "hex",
  "huff-neo-lexer",
  "huff-neo-utils",
+ "indexmap 2.8.0",
  "regex",
  "tracing",
 ]
@@ -3607,6 +3603,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
  "cfg-if",
+ "indexmap 2.8.0",
  "itertools 0.14.0",
  "js-sys",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,18 +23,19 @@ huff-neo-utils = { path = "crates/utils" }
 
 alloy-dyn-abi = "0.8.23"
 alloy-primitives = "0.8.23"
-anvil = { package = "anvil", git = "https://github.com/foundry-rs/foundry", rev = "a7e3421" }
+anvil = { package = "anvil", git = "https://github.com/foundry-rs/foundry", rev = "967a89e" }
 cfg-if = "1.0.0"
 clap = { version = "4.5.32", features = ["derive"] }
 comfy-table = "7.1.4"
 eyre = "0.6.12"
-foundry-cli = { git = "https://github.com/foundry-rs/foundry", rev = "a7e3421" }
-foundry-common = { git = "https://github.com/foundry-rs/foundry", rev = "a7e3421" }
-foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "a7e3421" }
-foundry-debugger = { git = "https://github.com/foundry-rs/foundry", rev = "a7e3421" }
-foundry-evm = { git = "https://github.com/foundry-rs/foundry", rev = "a7e3421" }
-foundry-evm-traces = { git = "https://github.com/foundry-rs/foundry", rev = "a7e3421" }
+foundry-cli = { git = "https://github.com/foundry-rs/foundry", rev = "967a89e" }
+foundry-common = { git = "https://github.com/foundry-rs/foundry", rev = "967a89e" }
+foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "967a89e" }
+foundry-debugger = { git = "https://github.com/foundry-rs/foundry", rev = "967a89e" }
+foundry-evm = { git = "https://github.com/foundry-rs/foundry", rev = "967a89e" }
+foundry-evm-traces = { git = "https://github.com/foundry-rs/foundry", rev = "967a89e" }
 hex = "0.4.3"
+indexmap = "2.8.0"
 itertools = "0.14.0"
 js-sys = { version = "0.3.77" }
 lazy_static = "1.5.0"

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -16,6 +16,7 @@ huff-neo-utils.workspace = true
 
 alloy-dyn-abi.workspace = true
 alloy-primitives.workspace = true
+indexmap.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/codegen/README.md
+++ b/crates/codegen/README.md
@@ -30,22 +30,24 @@ use std::sync::Arc;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-// Instantiate an empty Codegen
-let mut cg = Codegen::new();
-assert!(cg.ast.is_none());
-assert!(cg.artifact.is_none());
+fn example() {
+    // Instantiate an empty Codegen
+    let mut cg = Codegen::new();
+    assert!(cg.ast.is_none());
+    assert!(cg.artifact.is_none());
 
-// ERC20 Bytecode
-let main_bytecode = "5f3560e01c8063a9059cbb1461004757806340c10f19146100d757806370a082311461014157806318160ddd1461015c578063095ea7b314610166578063dd62ed3e1461017d575b600435336024358160016000526000602001526040600020548082116100d3578190038260016000526000602001526040600020558281906001600052600060200152604060002054018360016000526000602001526040600020555f527fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef60205fa360015f5260205ff35b5f5ffd5b5f5433146100e3575f5ffd5b6004355f60243582819060016000526000602001526040600020540183600160005260006020015260406000205580600254016002555f527fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef60205fa35b60043560016000526000602001526040600020545f5260205ff35b6002545f5260205ff35b602435600435336000526000602001526040600020555b6024356004356000526000602001526040600020545f5260205ff3";
-let constructor_bytecode = "335f55";
-let inputs = vec![];
-let churn_res = cg.churn(Arc::new(FileSource::default()), inputs, main_bytecode, constructor_bytecode, false);
+    // ERC20 Bytecode
+    let main_bytecode = "5f3560e01c8063a9059cbb1461004757806340c10f19146100d757806370a082311461014157806318160ddd1461015c578063095ea7b314610166578063dd62ed3e1461017d575b600435336024358160016000526000602001526040600020548082116100d3578190038260016000526000602001526040600020558281906001600052600060200152604060002054018360016000526000602001526040600020555f527fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef60205fa360015f5260205ff35b5f5ffd5b5f5433146100e3575f5ffd5b6004355f60243582819060016000526000602001526040600020540183600160005260006020015260406000205580600254016002555f527fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef60205fa35b60043560016000526000602001526040600020545f5260205ff35b6002545f5260205ff35b602435600435336000526000602001526040600020555b6024356004356000526000602001526040600020545f5260205ff3";
+    let constructor_bytecode = "335f55";
+    let inputs = vec![];
+    let churn_res = cg.churn(Arc::new(FileSource::default()), inputs, main_bytecode, constructor_bytecode, false);
 
-// Validate the output bytecode
-assert_eq!(churn_res.unwrap().bytecode, "335f5561019980600d3d393df35f3560e01c8063a9059cbb1461004757806340c10f19146100d757806370a082311461014157806318160ddd1461015c578063095ea7b314610166578063dd62ed3e1461017d575b600435336024358160016000526000602001526040600020548082116100d3578190038260016000526000602001526040600020558281906001600052600060200152604060002054018360016000526000602001526040600020555f527fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef60205fa360015f5260205ff35b5f5ffd5b5f5433146100e3575f5ffd5b6004355f60243582819060016000526000602001526040600020540183600160005260006020015260406000205580600254016002555f527fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef60205fa35b60043560016000526000602001526040600020545f5260205ff35b6002545f5260205ff35b602435600435336000526000602001526040600020555b6024356004356000526000602001526040600020545f5260205ff3".to_lowercase());
+    // Validate the output bytecode
+    assert_eq!(churn_res.unwrap().bytecode, "335f5561019980600d3d393df35f3560e01c8063a9059cbb1461004757806340c10f19146100d757806370a082311461014157806318160ddd1461015c578063095ea7b314610166578063dd62ed3e1461017d575b600435336024358160016000526000602001526040600020548082116100d3578190038260016000526000602001526040600020558281906001600052600060200152604060002054018360016000526000602001526040600020555f527fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef60205fa360015f5260205ff35b5f5ffd5b5f5433146100e3575f5ffd5b6004355f60243582819060016000526000602001526040600020540183600160005260006020015260406000205580600254016002555f527fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef60205fa35b60043560016000526000602001526040600020545f5260205ff35b6002545f5260205ff35b602435600435336000526000602001526040600020555b6024356004356000526000602001526040600020545f5260205ff3".to_lowercase());
 
-// Write the compile artifact out to a file
-// cg.export("./output.json");
+    // Write the compile artifact out to a file
+    // cg.export("./output.json");
+}
 ```
 
 Let's say you have a [Contract](../utils/ast/struct.Contract.html) instance with a simple **MAIN** macro. You can generate the main macro bytecode using the [generate_main_bytecode](struct.Codegen.html#method.generate_main_bytecode) function.
@@ -55,54 +57,57 @@ use huff_neo_codegen::*;
 use huff_neo_utils::prelude::*;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
+use indexmap::IndexMap;
 
-// Mock contract with a main macro
-let contract = Contract {
-  macros: vec![
-    MacroDefinition {
-      name: "MAIN".to_string(),
-      decorator: None,
-      parameters: vec![],
-      statements: vec![
-        Statement {
-          ty: StatementType::Literal(str_to_bytes32("00")),
+fn example() {
+    // Mock contract with a main macro
+    let contract = Contract {
+      macros: IndexMap::from([("MAIN".to_string(),
+        MacroDefinition {
+          name: "MAIN".to_string(),
+          decorator: None,
+          parameters: vec![],
+          statements: vec![
+            Statement {
+              ty: StatementType::Literal(str_to_bytes32("00")),
+              span: AstSpan(vec![]),
+            },
+            Statement {
+              ty: StatementType::Opcode(Opcode::Calldataload),
+              span: AstSpan(vec![]),
+            },
+            Statement {
+              ty: StatementType::Literal(str_to_bytes32("E0")),
+              span: AstSpan(vec![]),
+            },
+            Statement {
+              ty: StatementType::Opcode(Opcode::Shr),
+              span: AstSpan(vec![]),
+            }
+          ],
+          takes: 0,
+          returns: 0,
           span: AstSpan(vec![]),
-        },
-        Statement {
-          ty: StatementType::Opcode(Opcode::Calldataload),
-          span: AstSpan(vec![]),
-        },
-        Statement {
-          ty: StatementType::Literal(str_to_bytes32("E0")),
-          span: AstSpan(vec![]),
-        },
-        Statement {
-          ty: StatementType::Opcode(Opcode::Shr),
-          span: AstSpan(vec![]),
+          outlined: false,
+          test: false,
         }
-      ],
-      takes: 0,
-      returns: 0,
-      span: AstSpan(vec![]),
-      outlined: false,
-      test: false,
-    }
-  ],
-  invocations: vec![],
-  imports: vec![],
-  constants: Arc::new(Mutex::new(vec![])),
-  errors: vec![],
-  functions: vec![],
-  events: vec![],
-  tables: vec![],
-  labels: HashSet::new(),
-};
-
-// Generate the main bytecode
-let main_bytecode: String = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
-
-// Validate the output bytecode
-assert_eq!(main_bytecode, "5f3560e01c");
+      )]),
+      invocations: vec![],
+      imports: vec![],
+      constants: Arc::new(Mutex::new(vec![])),
+      errors: vec![],
+      functions: vec![],
+      events: vec![],
+      tables: vec![],
+      labels: HashSet::new(),
+    };
+    
+    // Generate the main bytecode
+    let main_bytecode: String = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
+    
+    // Validate the output bytecode
+    assert_eq!(main_bytecode, "5f3560e01c");
+}
 ```
 
 Similarly, once you have a [Contract](../utils/ast/struct.Contract.html) instance with a simple **CONSTRUCTOR** macro definition. You can generate the constructor/creation bytecode using the [generate_constructor_bytecode](struct.Codegen.html#method.generate_constructor_bytecode) function.
@@ -112,53 +117,56 @@ use huff_neo_codegen::*;
 use huff_neo_utils::prelude::*;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
+use indexmap::IndexMap;
 
-// Mock contract with a constructor macro
-let contract = Contract {
-  macros: vec![
-    MacroDefinition {
-      name: "CONSTRUCTOR".to_string(),
-      decorator: None,
-      parameters: vec![],
-      statements: vec![
-        Statement {
-          ty: StatementType::Literal(str_to_bytes32("00")),
-          span: AstSpan(vec![]),
-        },
-        Statement {
-          ty: StatementType::Opcode(Opcode::Calldataload),
-          span: AstSpan(vec![]),
-        },
-        Statement {
-          ty: StatementType::Literal(str_to_bytes32("E0")),
-          span: AstSpan(vec![]),
-        },
-        Statement {
-          ty: StatementType::Opcode(Opcode::Shr),
-          span: AstSpan(vec![]),
-        }
-      ],
-      takes: 0,
-      returns: 0,
-      span: AstSpan(vec![]),
-      outlined: false,
-      test: false,
-    }
-  ],
-  invocations: vec![],
-  imports: vec![],
-  constants: Arc::new(Mutex::new(vec![])),
-  errors: vec![],
-  functions: vec![],
-  events: vec![],
-  tables: vec![],
-  labels: HashSet::new(),
-};
+fn example() {
+    // Mock contract with a constructor macro
+    let contract = Contract {
+        macros: IndexMap::from([("CONSTRUCTOR".to_string(),
+            MacroDefinition {
+                name: "CONSTRUCTOR".to_string(),
+                decorator: None,
+                parameters: vec![],
+                statements: vec![
+                    Statement {
+                        ty: StatementType::Literal(str_to_bytes32("00")),
+                        span: AstSpan(vec![]),
+                    },
+                    Statement {
+                        ty: StatementType::Opcode(Opcode::Calldataload),
+                        span: AstSpan(vec![]),
+                    },
+                    Statement {
+                        ty: StatementType::Literal(str_to_bytes32("E0")),
+                        span: AstSpan(vec![]),
+                    },
+                    Statement {
+                        ty: StatementType::Opcode(Opcode::Shr),
+                        span: AstSpan(vec![]),
+                    }
+                ],
+                takes: 0,
+                returns: 0,
+                span: AstSpan(vec![]),
+                outlined: false,
+                test: false,
+            }
+        )]),
+        invocations: vec![],
+        imports: vec![],
+        constants: Arc::new(Mutex::new(vec![])),
+        errors: vec![],
+        functions: vec![],
+        events: vec![],
+        tables: vec![],
+        labels: HashSet::new(),
+    };
 
-// Generate the constructor bytecode
-let (constructor_bytecode, has_custom_bootstrap): (String, bool) = Codegen::generate_constructor_bytecode(&EVMVersion::default(), &contract, None).unwrap();
+    // Generate the constructor bytecode
+    let (constructor_bytecode, has_custom_bootstrap): (String, bool) = Codegen::generate_constructor_bytecode(&EVMVersion::default(), &contract, None).unwrap();
 
-// Validate the output bytecode
-assert_eq!(constructor_bytecode, "5f3560e01c");
-assert_eq!(has_custom_bootstrap, false);
+    // Validate the output bytecode
+    assert_eq!(constructor_bytecode, "5f3560e01c");
+    assert_eq!(has_custom_bootstrap, false);
+}
 ```

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -594,7 +594,7 @@ impl Codegen {
         table_instances: &mut Jumps,
         mut bytes: Vec<(usize, Bytes)>,
     ) -> Result<Vec<(usize, Bytes)>, CodegenError> {
-        for macro_def in contract.macros.iter().filter(|m| m.outlined) {
+        for macro_def in contract.macros.values().filter(|m| m.outlined) {
             // Push the function to the scope
             scope.push(macro_def);
 

--- a/crates/codegen/tests/abigen.rs
+++ b/crates/codegen/tests/abigen.rs
@@ -1,6 +1,7 @@
 use huff_neo_codegen::Codegen;
 use huff_neo_utils::ast::span::AstSpan;
 use huff_neo_utils::prelude::*;
+use indexmap::IndexMap;
 use std::collections::HashSet;
 use std::{
     collections::BTreeMap,
@@ -21,7 +22,7 @@ fn constructs_valid_abi() {
         test: false,
     };
     let contract = Contract {
-        macros: vec![constructor],
+        macros: IndexMap::from([("CONSTRUCTOR".to_string(), constructor)]),
         invocations: vec![],
         imports: vec![],
         constants: Arc::new(Mutex::new(vec![])),
@@ -62,7 +63,7 @@ fn missing_constructor_fails() {
         test: false,
     };
     let contract = Contract {
-        macros: vec![],
+        macros: IndexMap::new(),
         invocations: vec![],
         imports: vec![],
         constants: Arc::new(Mutex::new(vec![])),

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -17,5 +17,6 @@ huff-neo-utils.workspace = true
 
 alloy-primitives.workspace = true
 hex.workspace = true
+indexmap.workspace = true
 regex.workspace = true
 tracing.workspace = true

--- a/crates/parser/README.md
+++ b/crates/parser/README.md
@@ -21,45 +21,49 @@ use huff_neo_lexer::{Lexer};
 use huff_neo_parser::{Parser};
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
+use indexmap::IndexMap;
 
-// Create a Lexer from the source code
-let source = "#define macro HELLO_WORLD() = takes(0) returns(0) {}";
-let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-let mut lexer = Lexer::new(flattened_source);
-
-// Grab the tokens from the lexer
-let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
-
-// Parser incantation
-let mut parser = Parser::new(tokens, None);
-
-// Parse into an AST
-let unwrapped_contract = parser.parse().unwrap();
-assert_eq!(parser.current_token.kind, TokenKind::Eof);
-
-// Validate the unwrapped contract
-let expected_contract = Contract {
-  macros: vec![
-    MacroDefinition {
-      name: "HELLO_WORLD".to_string(),
-      decorator: None,
-      parameters: vec![],
-      statements: vec![],
-      takes: 0,
-      returns: 0,
-      span: AstSpan(vec![Span { start: 0, end: 6, file: None }, Span { start: 8, end: 12, file: None }, Span { start: 14, end: 24, file: None }, Span { start: 25, end: 25, file: None }, Span { start: 26, end: 26, file: None }, Span { start: 28, end: 28, file: None }, Span { start: 30, end: 34, file: None }, Span { start: 35, end: 35, file: None }, Span { start: 36, end: 36, file: None }, Span { start: 37, end: 37, file: None }, Span { start: 39, end: 45, file: None }, Span { start: 46, end: 46, file: None }, Span { start: 47, end: 47, file: None }, Span { start: 48, end: 48, file: None }, Span { start: 50, end: 50, file: None }, Span { start: 51, end: 51, file: None }]),
-      outlined: false,
-      test: false,
-    }
-  ],
-  invocations: vec![],
-  imports: vec![],
-  constants: Arc::new(Mutex::new(vec![])),
-  errors: vec![],
-  functions: vec![],
-  events: vec![],
-  tables: vec![],
-  labels: HashSet::new(),
-};
-assert_eq!(unwrapped_contract.macros, expected_contract.macros);
+fn example() {
+    
+    // Create a Lexer from the source code
+    let source = "#define macro HELLO_WORLD() = takes(0) returns(0) {}";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+    
+    // Grab the tokens from the lexer
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    
+    // Parser incantation
+    let mut parser = Parser::new(tokens, None);
+    
+    // Parse into an AST
+    let unwrapped_contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+    
+    // Validate the unwrapped contract
+    let expected_contract = Contract {
+      macros: IndexMap::from([("HELLO_WORLD".to_string(),
+        MacroDefinition {
+          name: "HELLO_WORLD".to_string(),
+          decorator: None,
+          parameters: vec![],
+          statements: vec![],
+          takes: 0,
+          returns: 0,
+          span: AstSpan(vec![Span { start: 0, end: 6, file: None }, Span { start: 8, end: 12, file: None }, Span { start: 14, end: 24, file: None }, Span { start: 25, end: 25, file: None }, Span { start: 26, end: 26, file: None }, Span { start: 28, end: 28, file: None }, Span { start: 30, end: 34, file: None }, Span { start: 35, end: 35, file: None }, Span { start: 36, end: 36, file: None }, Span { start: 37, end: 37, file: None }, Span { start: 39, end: 45, file: None }, Span { start: 46, end: 46, file: None }, Span { start: 47, end: 47, file: None }, Span { start: 48, end: 48, file: None }, Span { start: 50, end: 50, file: None }, Span { start: 51, end: 51, file: None }]),
+          outlined: false,
+          test: false,
+        }
+      )]),
+      invocations: vec![],
+      imports: vec![],
+      constants: Arc::new(Mutex::new(vec![])),
+      errors: vec![],
+      functions: vec![],
+      events: vec![],
+      tables: vec![],
+      labels: HashSet::new(),
+    };
+    assert_eq!(unwrapped_contract.macros, expected_contract.macros);
+}
 ```

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -73,7 +73,7 @@ impl Parser {
             else if self.check(TokenKind::Pound) {
                 let m = self.parse_macro(&mut contract)?;
                 tracing::info!(target: "parser", "SUCCESSFULLY PARSED MACRO {}", m.name);
-                contract.macros.push(m);
+                contract.macros.insert(m.name.clone(), m);
             }
             // Check for a definition with the "#define" keyword
             else if self.check(TokenKind::Define) {
@@ -106,12 +106,12 @@ impl Parser {
                         let m = self.parse_macro(&mut contract)?;
                         tracing::info!(target: "parser", "SUCCESSFULLY PARSED MACRO {}", m.name);
                         self.check_duplicate_macro(&contract, &m)?;
-                        contract.macros.push(m);
+                        contract.macros.insert(m.name.clone(), m);
                     }
                     TokenKind::Test => {
                         let m = self.parse_macro(&mut contract)?;
                         tracing::info!(target: "parser", "SUCCESSFULLY PARSED TEST {}", m.name);
-                        contract.macros.push(m);
+                        contract.macros.insert(m.name.clone(), m);
                     }
                     TokenKind::JumpTable | TokenKind::JumpTablePacked | TokenKind::CodeTable => {
                         contract.tables.push(self.parse_table()?);
@@ -215,7 +215,7 @@ impl Parser {
 
     /// Checks if there is a duplicate macro name
     pub fn check_duplicate_macro(&self, contract: &Contract, m: &MacroDefinition) -> Result<(), ParserError> {
-        if contract.macros.binary_search_by(|_macro| _macro.name.cmp(&m.name)).is_ok() {
+        if contract.macros.contains_key(&m.name) {
             tracing::error!(target: "parser", "DUPLICATE MACRO NAME FOUND: {}",  m.name);
             Err(ParserError {
                 kind: ParserErrorKind::DuplicateMacro(m.name.to_owned()),

--- a/crates/parser/tests/labels.rs
+++ b/crates/parser/tests/labels.rs
@@ -21,8 +21,7 @@ fn multiline_labels() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let md_expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -196,8 +195,7 @@ pub fn builtins_under_labels() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[1].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let md_expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         parameters: vec![],

--- a/crates/parser/tests/macro.rs
+++ b/crates/parser/tests/macro.rs
@@ -13,8 +13,7 @@ fn empty_macro() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -55,8 +54,7 @@ fn empty_macro_without_takes_returns() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -89,8 +87,7 @@ fn empty_macro_only_takes() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -127,8 +124,7 @@ fn empty_macro_only_returns() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -165,8 +161,7 @@ fn macro_with_simple_body() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -240,8 +235,7 @@ fn macro_with_arg_calls() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("TRANSFER_TAKE_FROM").cloned().unwrap();
     let expected = MacroDefinition {
         name: "TRANSFER_TAKE_FROM".to_string(),
         parameters: vec![Argument {
@@ -381,8 +375,7 @@ fn macro_labels() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("LABEL_FILLED").cloned().unwrap();
     let expected = MacroDefinition {
         name: "LABEL_FILLED".to_string(),
         decorator: None,
@@ -556,8 +549,7 @@ fn macro_invocation_with_arg_call() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("ARG_CALL").cloned().unwrap();
     let expected = MacroDefinition {
         name: "ARG_CALL".to_string(),
         decorator: None,
@@ -680,8 +672,7 @@ fn test_macro_opcode_arguments() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("MAIN").cloned().unwrap();
     let expected = MacroDefinition {
         name: "MAIN".to_string(),
         decorator: None,
@@ -751,8 +742,7 @@ fn macro_with_builtin_fn_call() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("BUILTIN_TEST").cloned().unwrap();
     let expected = MacroDefinition {
         name: "BUILTIN_TEST".to_string(),
         decorator: None,
@@ -813,8 +803,7 @@ fn empty_outlined_macro() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -855,8 +844,7 @@ fn outlined_macro_with_simple_body() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -908,8 +896,7 @@ fn empty_test() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -950,8 +937,7 @@ fn test_with_simple_body() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("HELLO_WORLD").cloned().unwrap();
     let expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -1028,8 +1014,7 @@ fn empty_test_with_decorator() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("MY_TEST").cloned().unwrap();
     let expected = MacroDefinition {
         name: String::from("MY_TEST"),
         decorator: Some(Decorator {
@@ -1084,8 +1069,7 @@ fn empty_test_with_multi_flag_decorator() {
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens, None);
 
-    // Grab the first macro
-    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let macro_definition = parser.parse().unwrap().macros.get("MY_TEST").cloned().unwrap();
     let expected = MacroDefinition {
         name: String::from("MY_TEST"),
         decorator: Some(Decorator {

--- a/crates/test-runner/src/lib.rs
+++ b/crates/test-runner/src/lib.rs
@@ -119,7 +119,7 @@ impl<'t> HuffTester<'t> {
             ast,
             macros: {
                 // Filter all macros within the AST for `test` macros only
-                let mut macros: TestMacros<'t> = ast.macros.iter().filter(|m| m.test).collect();
+                let mut macros: TestMacros<'t> = ast.macros.values().filter(|m| m.test).collect();
                 // If the match flag is present, only retain the test macro
                 // that was queried
                 if let Some(match_test_name) = match_test_name {

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["bytecode", "compiler", "evm", "huff", "rust"]
 alloy-dyn-abi.workspace = true
 alloy-primitives.workspace = true
 cfg-if.workspace = true
+indexmap.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
 phf.workspace = true

--- a/crates/utils/src/abi.rs
+++ b/crates/utils/src/abi.rs
@@ -10,6 +10,7 @@
 //!
 //! ```rust
 //! use std::sync::{Arc, Mutex};
+//! use indexmap::IndexMap;
 //! use huff_neo_utils::ast::abi::FunctionType;
 //! use huff_neo_utils::ast::span::AstSpan;
 //! use huff_neo_utils::prelude::*;
@@ -17,7 +18,7 @@
 //! // Generate a default contract for demonstrative purposes.
 //! // Realistically, contract generation would be done as shown in [huff_parser](./huff_parser)
 //! let contract = Contract {
-//!     macros: vec![],
+//!     macros: IndexMap::new(),
 //!     invocations: vec![],
 //!     imports: vec![],
 //!     constants: Arc::new(Mutex::new(vec![])),
@@ -95,19 +96,17 @@ impl From<huff::Contract> for Abi {
                     .collect(),
             })
             .or_else(|| {
-                contract.macros.iter().filter(|m| m.name == "CONSTRUCTOR").cloned().collect::<Vec<huff::MacroDefinition>>().first().map(
-                    |func| Constructor {
-                        inputs: func
-                            .parameters
-                            .iter()
-                            .map(|argument| FunctionParam {
-                                name: argument.name.clone().unwrap_or_default(),
-                                kind: argument.name.clone().unwrap_or_default().into(),
-                                internal_type: None,
-                            })
-                            .collect(),
-                    },
-                )
+                contract.macros.get("CONSTRUCTOR").map(|func| Constructor {
+                    inputs: func
+                        .parameters
+                        .iter()
+                        .map(|argument| FunctionParam {
+                            name: argument.name.clone().unwrap_or_default(),
+                            kind: argument.name.clone().unwrap_or_default().into(),
+                            internal_type: None,
+                        })
+                        .collect(),
+                })
             });
 
         // Instantiate functions and events


### PR DESCRIPTION
Now using IndexMap instead of Vec to keep track of macros of a contract. This removes the need for `binary_search_by` and restrict now the name usage for macro, test and fn.