### PR TITLE
chore: Remove `AUTH` and `AUTHCALL` opcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [1.1.10] - 2025-05-30
+- Remove `AUTH` and `AUTHCALL` opcodes since EIP-3074 was withdrawn from Pectra.
+  - See: https://github.com/ethereum/EIPs/pull/9771
+
 ## [1.1.9] - 2025-05-29
 - Hotfix to get `huff-js` wasm compiling.
 

--- a/crates/utils/src/evm_version.rs
+++ b/crates/utils/src/evm_version.rs
@@ -12,7 +12,7 @@ pub enum SupportedEVMVersions {
     Shanghai,
     /// Introduced TLOAD, TSTORE, MCOPY, BLOBHASH, and BLOBBASEFEE
     Cancun,
-    /// Introduced AUTH and AUTHCALL
+    /// No new opcodes
     #[default]
     Prague,
     /// No new opcodes

--- a/crates/utils/src/opcodes.rs
+++ b/crates/utils/src/opcodes.rs
@@ -6,13 +6,11 @@ use strum_macros::EnumString;
 /// They are arranged in a particular order such that all the opcodes that have common
 /// prefixes are ordered alphabetically by decreasing length to avoid mismatch when lexing.
 /// Example : [origin, or] or [push32, ..., push3]
-pub const OPCODES: [&str; 152] = [
+pub const OPCODES: [&str; 150] = [
     "addmod",
     "address",
     "add",
     "and",
-    "authcall",
-    "auth",
     "balance",
     "basefee",
     "blobbasefee",
@@ -313,8 +311,6 @@ pub static OPCODES_MAP: phf::Map<&'static str, Opcode> = phf_map! {
     "revert" => Opcode::Revert,
     "invalid" => Opcode::Invalid,
     "selfdestruct" => Opcode::Selfdestruct,
-    "auth" => Opcode::Auth,
-    "authcall" => Opcode::Authcall,
 };
 
 /// EVM Opcodes
@@ -623,10 +619,6 @@ pub enum Opcode {
     Selfdestruct,
     /// Get hash of an account’s code
     Extcodehash,
-    /// Preparatory operation for AUTHCALL
-    Auth,
-    /// Call with callee set to externally owned account
-    Authcall,
 }
 
 impl Opcode {
@@ -779,8 +771,6 @@ impl Opcode {
             Opcode::Return => "f3",
             Opcode::Delegatecall => "f4",
             Opcode::Create2 => "f5",
-            Opcode::Auth => "f6",
-            Opcode::Authcall => "f7",
             Opcode::Staticcall => "fa",
             Opcode::Revert => "fd",
             Opcode::Invalid => "fe",


### PR DESCRIPTION
- Remove `AUTH` and `AUTHCALL` opcodes since EIP-3074 was withdrawn from Pectra.
  - See: https://github.com/ethereum/EIPs/pull/9771