### PR TITLE
Fix nested macro argument resolution (#62)

### DIFF
--- a/crates/core/tests/nested_macro_argcalls.rs
+++ b/crates/core/tests/nested_macro_argcalls.rs
@@ -1,0 +1,217 @@
+use huff_neo_codegen::Codegen;
+use huff_neo_lexer::*;
+use huff_neo_parser::Parser;
+use huff_neo_utils::file::full_file_source::FullFileSource;
+use huff_neo_utils::prelude::*;
+
+/// Tests for ArgCall resolution within nested macro invocations
+///
+/// These tests verify that argument calls (`<arg>`) within macro call arguments
+/// are properly resolved by traversing the scope chain to find their definitions.
+///
+/// Example pattern: ADD(GET(<ddd>), 0x02) where <ddd> is defined in a parent scope
+
+#[test]
+fn test_simple_argcall_in_nested_macrocall() {
+    // Basic case: ArgCall directly within MacroCall argument
+    // Pattern: ParentMacro(ChildMacro(<arg>))
+    let source = r#"
+        #define macro GET(aaa) = takes(0) returns(1) {
+            <aaa>
+        }
+
+        #define macro RUN(ddd) = takes(0) returns(1) {
+            GET(<ddd>)
+        }
+
+        #define macro MAIN() = takes(0) returns(1) {
+            RUN(0x01)
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let main_bytecode = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
+
+    // Expected: PUSH1 0x01
+    assert_eq!(main_bytecode.to_lowercase(), "6001");
+}
+
+#[test]
+fn test_argcall_in_macrocall_with_multiple_args() {
+    // Core case: ArgCall within MacroCall as one of multiple arguments
+    // Pattern: ParentMacro(ChildMacro(<arg>), literal)
+    let source = r#"
+        #define macro GET(aaa) = takes(0) returns(1) {
+            <aaa>
+        }
+
+        #define macro ADD(bbb, ccc) = takes(2) returns(1) {
+            <bbb> <ccc> add
+        }
+
+        #define macro RUN(ddd) = takes(0) returns(1) {
+            ADD(GET(<ddd>), 0x02)
+        }
+
+        #define macro MAIN() = takes(0) returns(1) {
+            RUN(0x01)
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let main_bytecode = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
+
+    // Expected: PUSH1 0x01, PUSH1 0x02, ADD
+    assert_eq!(main_bytecode.to_lowercase(), "6001600201");
+}
+
+#[test]
+fn test_multiple_argcalls_in_macrocall() {
+    // Advanced case: Multiple ArgCalls within same MacroCall
+    // Pattern: ParentMacro(ChildMacro(<arg1>), <arg2>)
+    let source = r#"
+        #define macro GET(aaa) = takes(0) returns(1) {
+            <aaa>
+        }
+
+        #define macro ADD(bbb, ccc) = takes(2) returns(1) {
+            <bbb> <ccc> add
+        }
+
+        #define macro RUN(ddd, eee) = takes(0) returns(1) {
+            ADD(GET(<ddd>), <eee>)
+        }
+
+        #define macro MAIN() = takes(0) returns(1) {
+            RUN(0x01, 0x02)
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let main_bytecode = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
+
+    // Expected: PUSH1 0x01, PUSH1 0x02, ADD
+    assert_eq!(main_bytecode.to_lowercase(), "6001600201");
+}
+
+#[test]
+fn test_deeply_nested_argcalls() {
+    // Complex case: Multiple levels of nesting with ArgCalls at different levels
+    // Pattern: GrandParent(Parent(Child(<arg1>), <arg2>), <arg3>)
+    let source = r#"
+        #define macro GET(aaa) = takes(0) returns(1) {
+            <aaa>
+        }
+
+        #define macro ADD(bbb, ccc) = takes(2) returns(1) {
+            <bbb> <ccc> add
+        }
+
+        #define macro STORE(operation, offset) = takes(0) returns(0) {
+            <operation> <offset> mstore
+        }
+
+        #define macro RUN(ddd, eee, fff) = takes(0) returns(0) {
+            STORE(ADD(GET(<ddd>), <eee>), <fff>)
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            RUN(0x01, 0x02, 0x00)
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let main_bytecode = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
+
+    // Expected: PUSH1 0x01, PUSH1 0x02, ADD, PUSH1 0x00, MSTORE
+    assert_eq!(main_bytecode.to_lowercase(), "60016002015f52");
+}
+
+#[test]
+fn test_argcall_scope_chain_traversal() {
+    // Tests that ArgCalls properly traverse scope chain to find definitions
+    // When <arg> is not found in immediate macro, it should bubble up to parent scopes
+    let source = r#"
+        #define macro INNER(param) = takes(0) returns(1) {
+            <param>
+        }
+
+        #define macro MIDDLE() = takes(0) returns(1) {
+            INNER(<outer_param>)  // outer_param not defined in MIDDLE, should bubble to OUTER
+        }
+
+        #define macro OUTER(outer_param) = takes(0) returns(1) {
+            MIDDLE()
+        }
+
+        #define macro MAIN() = takes(0) returns(1) {
+            OUTER(0x42)
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let main_bytecode = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
+
+    // Expected: PUSH1 0x42
+    assert_eq!(main_bytecode.to_lowercase(), "6042");
+}
+
+#[test]
+fn test_undefined_argcall_in_macrocall_errors() {
+    // Ensures that truly undefined ArgCalls within MacroCalls still error appropriately
+    let source = r#"
+        #define macro GET(aaa) = takes(0) returns(1) {
+            <undefined_arg>  // This arg is not defined anywhere
+        }
+
+        #define macro RUN(ddd) = takes(0) returns(1) {
+            GET(<ddd>)
+        }
+
+        #define macro MAIN() = takes(0) returns(1) {
+            RUN(0x01)
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None);
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind, CodegenErrorKind::MissingArgumentDefinition(String::from("undefined_arg")));
+}


### PR DESCRIPTION
## Summary

Fixes compilation errors when ArgCalls (`<arg>`) appear within nested macro call arguments where the argument is defined in a parent scope.

Resolves #62

## Problem

When processing nested macro calls like:

```huff
#define macro GET(aaa) = takes(0) returns(1) {
    <aaa>
}

#define macro ADD(bbb, ccc) = takes(2) returns(1) {
    <bbb> <ccc> add
}

#define macro RUN(ddd) = takes(0) returns(1) {
    ADD(GET(<ddd>), 0x02)
}
```

The compiler would fail with `MissingArgumentDefinition("ddd")` because it tried to resolve `<ddd>` in the `GET` macro's parameter scope instead of traversing up to the `RUN` macro where `ddd` is actually defined.

## Root Cause

The `bubble_arg_call` function in `arg_calls.rs` did not properly handle scope traversal when an ArgCall was not found in the current macro's parameters. Instead of bubbling up to parent scopes, it would immediately error with `MissingArgumentDefinition`.

## Solution

Modified `bubble_arg_call` function to implement proper scope chain traversal:

1. **Check current scope**: Look for argument in current macro's parameters
2. **Bubble up if not found**: If argument not found and parent scopes exist (`scope.len() > 1 && mis.len() > 1`)
3. **Recursively traverse**: Continue bubbling up through parent macro definitions  
4. **Error at top level**: Only error with `MissingArgumentDefinition` if no parent scopes remain

## Key Changes

### `crates/codegen/src/irgen/arg_calls.rs`
- Enhanced argument resolution logic with scope chain traversal
- Added proper parent scope detection and recursive bubbling
- Maintains backward compatibility and error handling

### `crates/core/tests/nested_macro_argcalls.rs` (New)
- Comprehensive test suite covering all nested ArgCall scenarios
- Tests basic, intermediate, and complex nesting patterns
- Verifies scope chain traversal and error handling

## Test Coverage

✅ **Basic ArgCall resolution** - `GET(<ddd>)` patterns  
✅ **Multiple argument scenarios** - `ADD(GET(<ddd>), 0x02)` patterns  
✅ **Complex multi-level nesting** - `STORE(ADD(GET(<ddd>), <eee>), <fff>)` patterns  
✅ **Scope chain traversal** - Arguments defined multiple scopes up  
✅ **Error handling** - Undefined arguments still error correctly  
✅ **Backward compatibility** - All existing tests continue to pass  

## Examples That Now Work

```huff
// Basic case
#define macro GET(aaa) = takes(0) returns(1) { <aaa> }
#define macro RUN(ddd) = takes(0) returns(1) { GET(<ddd>) }

// Multiple arguments  
#define macro ADD(bbb, ccc) = takes(2) returns(1) { <bbb> <ccc> add }
#define macro RUN(ddd) = takes(0) returns(1) { ADD(GET(<ddd>), 0x02) }

// Deep nesting
#define macro STORE(operation, offset) = takes(0) returns(0) { <operation> <offset> mstore }
#define macro RUN(ddd, eee, fff) = takes(0) returns(0) { STORE(ADD(GET(<ddd>), <eee>), <fff>) }

// Scope traversal
#define macro INNER(param) = takes(0) returns(1) { <param> }
#define macro MIDDLE() = takes(0) returns(1) { INNER(<outer_param>) }
#define macro OUTER(outer_param) = takes(0) returns(1) { MIDDLE() }
```

## Testing

All tests pass including:
- 6 new nested macro ArgCall tests  
- 17 existing macro argument tests
- 87 total tests across the entire test suite

🤖 Generated with [Claude Code](https://claude.ai/code)