### PR TITLE
fix: handle nested macro expansions correctly in source mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+## [1.3.2] - 2025-08-14
+- Standardize span convention to use exclusive end positions (following Rust Range convention).
+  - All spans now use `start..end` where `end` is exclusive (points after the last character).
+- Fix source mapping to correctly handle nested macro expansions.
+  - Spans now point to actual opcodes in macro definitions, not invocations.
+
 ## [1.3.1] - 2025-08-14
 - Add constructor and runtime source maps in Artifact structure.
 - Remove UUID field from FileSource struct for better WASM compatibility.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "hnc"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -4061,7 +4061,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "huff-neo-codegen"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-core"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-js"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "huff-neo-core",
  "huff-neo-utils",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-lexer"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "huff-neo-utils",
  "lazy_static",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-parser"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "alloy-primitives",
  "huff-neo-lexer",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-test-runner"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4148,7 +4148,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-utils"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/cakevm/huff-neo"
 rust-version = "1.89"
-version = "1.3.1"
+version = "1.3.2"
 
 [workspace.dependencies]
 huff-neo-codegen = { path = "crates/codegen" }

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -24,4 +24,6 @@
 - [CLI](cli.md)
 - [Style Guide](style-guide.md)
 - [Resources](resources.md)
+- [Developer Guide](developers/overview.md)
+  - [Understanding Spans](developers/spans.md)
 - [Contribute](contribute.md)

--- a/book/developers/overview.md
+++ b/book/developers/overview.md
@@ -1,0 +1,7 @@
+# Developer Guide
+
+This section provides technical documentation for developers working on the Huff Neo compiler itself.
+
+## Topics
+
+- [Understanding Spans](spans.md) - How source location tracking works in the compiler

--- a/book/developers/spans.md
+++ b/book/developers/spans.md
@@ -1,0 +1,158 @@
+# Understanding Spans
+
+Spans are a fundamental concept in the Huff Neo compiler that track the source location of tokens, AST nodes, and bytecode. They enable accurate error reporting and source mapping for debugging.
+
+## What is a Span?
+
+A `Span` represents a range of characters in the source code:
+
+```rust,ignore
+pub struct Span {
+    pub start: usize,  // Byte offset where the span starts
+    pub end: usize,    // Byte offset where the span ends (exclusive)
+    pub file: Option<Arc<FileSource>>,  // Reference to the source file
+}
+```
+
+## Exclusive End Convention
+
+Huff Neo uses **exclusive end positions**, following Rust's `Range` convention:
+
+- `start` points to the first character of the span
+- `end` points to the position **after** the last character
+- This matches Rust's range syntax: `source[start..end]`
+
+### Example
+
+Given the source code:
+```huff
+#define macro MAIN() = takes(0) returns (0) {
+    0x42
+    add
+}
+```
+
+The span for the token `0x42` would be:
+- Text: `"0x42"`
+- Start: 50 (position of '0')
+- End: 54 (position after '2')
+- Length: 4 characters
+- Extract with: `source[50..54]` → `"0x42"`
+
+## Working with Spans
+
+### Creating Spans
+
+The lexer creates spans as it tokenizes:
+
+```rust,ignore
+// In the lexer, when we recognize a token:
+let start = self.position;  // Current position
+let token_text = self.eat_while(|c| c.is_alphanumeric());
+let end = self.position + token_text.len();  // Exclusive end
+
+Token {
+    kind: TokenKind::Ident(token_text),
+    span: Span::new(start..end, file)
+}
+```
+
+### Using Spans for Error Reporting
+
+Spans enable precise error messages:
+
+```rust,ignore
+// When reporting an error:
+return Err(CodegenError {
+    kind: CodegenErrorKind::UnmatchedJumpLabel,
+    span: label.span,  // Points exactly to the problematic label
+    token: Some(label.clone()),
+});
+```
+
+This produces output like:
+```text
+Error: Unmatched jump label
+   --> example.huff:5:8
+    |
+  5 |     unknown_label jumpi
+    |     ^^^^^^^^^^^^^
+```
+
+### Span Preservation During Compilation
+
+Spans flow through the compilation pipeline:
+
+1. **Lexer** → Creates initial spans for tokens
+2. **Parser** → Combines token spans into AST node spans
+3. **Codegen** → Preserves spans when generating bytecode
+4. **Source Maps** → Maps bytecode positions back to source spans
+
+## Special Cases
+
+### Macro Expansion
+
+When expanding macros, we preserve the span of the actual operation, not the invocation:
+
+```huff
+#define macro ADD() = takes(2) returns (1) {
+    add  // Span points here
+}
+
+#define macro MAIN() = takes(0) returns (0) {
+    0x01
+    0x02
+    ADD()  // NOT here - we want the span of 'add', not 'ADD()'
+}
+```
+
+The source map for the `add` opcode points to line 2, not line 8.
+
+### Constants and Arguments
+
+For constants and macro arguments, the span includes the brackets:
+
+```huff
+#define constant VALUE = 0x42
+
+#define macro MAIN() = takes(0) returns (0) {
+    [VALUE]  // Span covers all of "[VALUE]" including brackets
+}
+```
+
+### Jump Labels
+
+Jump labels have two different spans:
+
+1. **Label definition**: `label:` - Span covers "label:"
+2. **Label reference**: `label jumpi` - Span covers just "label"
+
+## Common Pitfalls
+
+### Off-by-One Errors
+
+Remember that `end` is exclusive:
+
+```rust,ignore
+// WRONG - treats end as inclusive
+let text = &source[span.start..=span.end];  
+
+// CORRECT - end is exclusive
+let text = &source[span.start..span.end];
+```
+
+### Multi-byte Characters
+
+Spans use byte offsets, not character counts. Be careful with UTF-8:
+
+```rust,ignore
+// The lexer handles this correctly by using byte positions
+let end_position = self.position + char.len_utf8();
+```
+
+### Empty Spans
+
+Empty spans (where `start == end`) are valid and used for:
+- EOF tokens
+- Inserted/synthetic tokens
+- Zero-width positions

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -428,7 +428,7 @@ impl Codegen {
                     if recursing_constructor {
                         continue;
                     }
-                    let mut push_bytes = statement_gen(
+                    let (mut push_bytes, mut push_spans) = statement_gen(
                         evm_version,
                         s,
                         contract,
@@ -443,10 +443,9 @@ impl Codegen {
                         circular_codesize_invocations,
                         starting_offset,
                     )?;
-                    // Add span for each byte segment added by statement_gen
-                    for _ in 0..push_bytes.len() {
-                        spans.push(span_info);
-                    }
+                    // Use the spans from statement_gen (which preserves nested macro spans)
+                    // instead of duplicating the parent's span
+                    spans.append(&mut push_spans);
                     bytes.append(&mut push_bytes);
                 }
                 IRByteType::ArgCall(parent_macro_name, arg_name) => {

--- a/crates/core/tests/codegen_errors.rs
+++ b/crates/core/tests/codegen_errors.rs
@@ -90,8 +90,8 @@ fn test_invalid_constant_definition() {
     }
   "#;
 
-    let const_start = source.find("UNKNOWN_CONSTANT_DEFINITION").unwrap_or(0);
-    let const_end = const_start + "UNKNOWN_CONSTANT_DEFINITION".len();
+    let const_start = source.find("[UNKNOWN_CONSTANT_DEFINITION").unwrap_or(0);
+    let const_end = const_start + "[UNKNOWN_CONSTANT_DEFINITION]".len();
 
     let full_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(full_source);

--- a/crates/core/tests/source_maps.rs
+++ b/crates/core/tests/source_maps.rs
@@ -1,0 +1,668 @@
+use std::sync::Arc;
+
+use huff_neo_core::Compiler;
+use huff_neo_utils::file::file_source::FileSource;
+use huff_neo_utils::prelude::*;
+
+#[test]
+fn test_exact_source_positions_simple() {
+    let source = r#"#define macro MAIN() = takes(0) returns (0) {
+    0x42
+    0x00
+    sstore
+}"#;
+
+    let full_source = FileSource { source: Some(source.to_string()), path: "test.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler = Compiler::new(&evm_version, Arc::new(vec!["test.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(full_source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+
+            assert_eq!(runtime_map.len(), 3);
+
+            // First entry: "0x42"
+            assert_eq!(runtime_map[0].byte_offset, 0);
+            assert_eq!(runtime_map[0].length, 4);
+            assert_eq!(runtime_map[0].source_start, 50);
+            assert_eq!(runtime_map[0].source_end, 54);
+            assert_eq!(&source[50..54], "0x42");
+
+            // Second entry: "0x00"
+            assert_eq!(runtime_map[1].byte_offset, 4);
+            assert_eq!(runtime_map[1].length, 2);
+            assert_eq!(runtime_map[1].source_start, 59);
+            assert_eq!(runtime_map[1].source_end, 63);
+            assert_eq!(&source[59..63], "0x00");
+
+            // Third entry: "sstore"
+            assert_eq!(runtime_map[2].byte_offset, 6);
+            assert_eq!(runtime_map[2].length, 2);
+            assert_eq!(runtime_map[2].source_start, 68);
+            assert_eq!(runtime_map[2].source_end, 74);
+            assert_eq!(&source[68..74], "sstore");
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}
+
+#[test]
+fn test_exact_positions_with_constructor() {
+    let source = r#"#define macro CONSTRUCTOR() = takes(0) returns (0) {
+    0x01
+    0x00
+    sstore
+}
+
+#define macro MAIN() = takes(0) returns (0) {
+    0x00
+    sload
+}"#;
+
+    let full_source = FileSource { source: Some(source.to_string()), path: "test.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler = Compiler::new(&evm_version, Arc::new(vec!["test.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(full_source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            // Check constructor map
+            assert!(artifact.constructor_map.is_some());
+            let constructor_map = artifact.constructor_map.unwrap();
+            assert_eq!(constructor_map.len(), 3);
+
+            // Constructor first: "0x01"
+            assert_eq!(constructor_map[0].byte_offset, 0);
+            assert_eq!(constructor_map[0].length, 4);
+            assert_eq!(constructor_map[0].source_start, 57);
+            assert_eq!(constructor_map[0].source_end, 61);
+            assert_eq!(&source[57..61], "0x01");
+
+            // Constructor second: "0x00"
+            assert_eq!(constructor_map[1].byte_offset, 4);
+            assert_eq!(constructor_map[1].length, 2);
+            assert_eq!(constructor_map[1].source_start, 66);
+            assert_eq!(constructor_map[1].source_end, 70);
+            assert_eq!(&source[66..70], "0x00");
+
+            // Constructor third: "sstore"
+            assert_eq!(constructor_map[2].byte_offset, 6);
+            assert_eq!(constructor_map[2].length, 2);
+            assert_eq!(constructor_map[2].source_start, 75);
+            assert_eq!(constructor_map[2].source_end, 81);
+            assert_eq!(&source[75..81], "sstore");
+
+            // Check runtime map
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+            assert_eq!(runtime_map.len(), 2);
+
+            // Runtime first: "0x00"
+            assert_eq!(runtime_map[0].byte_offset, 0);
+            assert_eq!(runtime_map[0].length, 2);
+            assert_eq!(runtime_map[0].source_start, 135);
+            assert_eq!(runtime_map[0].source_end, 139);
+            assert_eq!(&source[135..139], "0x00");
+
+            // Runtime second: "sload"
+            assert_eq!(runtime_map[1].byte_offset, 2);
+            assert_eq!(runtime_map[1].length, 2);
+            assert_eq!(runtime_map[1].source_start, 144);
+            assert_eq!(runtime_map[1].source_end, 149);
+            assert_eq!(&source[144..149], "sload");
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}
+
+#[test]
+fn test_exact_positions_nested_macro() {
+    let source = r#"#define macro ADD() = takes(2) returns (1) {
+    add
+}
+
+#define macro MAIN() = takes(0) returns (0) {
+    0x01
+    0x02
+    ADD()
+}"#;
+
+    let full_source = FileSource { source: Some(source.to_string()), path: "test.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler = Compiler::new(&evm_version, Arc::new(vec!["test.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(full_source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+            assert_eq!(runtime_map.len(), 3);
+
+            // First: "0x01"
+            assert_eq!(runtime_map[0].source_start, 106);
+            assert_eq!(runtime_map[0].source_end, 110);
+            assert_eq!(&source[106..110], "0x01");
+
+            // Second: "0x02"
+            assert_eq!(runtime_map[1].source_start, 115);
+            assert_eq!(runtime_map[1].source_end, 119);
+            assert_eq!(&source[115..119], "0x02");
+
+            // Third: "add" from inside ADD() macro definition (not the invocation)
+            assert_eq!(runtime_map[2].source_start, 49);
+            assert_eq!(runtime_map[2].source_end, 52);
+            assert_eq!(runtime_map[2].length, 2);
+            assert_eq!(&source[49..52], "add");
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}
+
+#[test]
+fn test_exact_positions_with_constant() {
+    let source = r#"#define constant VAL = 0x42
+
+#define macro MAIN() = takes(0) returns (0) {
+    [VAL]
+    0x00
+    mstore
+}"#;
+
+    let full_source = FileSource { source: Some(source.to_string()), path: "test.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler = Compiler::new(&evm_version, Arc::new(vec!["test.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(full_source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+            assert_eq!(runtime_map.len(), 3);
+
+            // First: [VAL] constant reference
+            assert_eq!(runtime_map[0].source_start, 79);
+            assert_eq!(runtime_map[0].source_end, 84);
+            assert_eq!(runtime_map[0].length, 4);
+            assert_eq!(&source[79..84], "[VAL]");
+
+            // Second: "0x00"
+            assert_eq!(runtime_map[1].source_start, 89);
+            assert_eq!(runtime_map[1].source_end, 93);
+            assert_eq!(runtime_map[1].length, 2);
+            assert_eq!(&source[89..93], "0x00");
+
+            // Third: "mstore"
+            assert_eq!(runtime_map[2].source_start, 98);
+            assert_eq!(runtime_map[2].source_end, 104);
+            assert_eq!(runtime_map[2].length, 2);
+            assert_eq!(&source[98..104], "mstore");
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}
+
+#[test]
+fn test_exact_positions_with_jumps() {
+    let source = r#"#define macro MAIN() = takes(0) returns (0) {
+    0x01
+    skip jumpi
+    0x02
+    skip:
+        0x03
+}"#;
+
+    let full_source = FileSource { source: Some(source.to_string()), path: "test.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler = Compiler::new(&evm_version, Arc::new(vec!["test.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(full_source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+            assert!(runtime_map.len() >= 5);
+
+            // First: "0x01"
+            assert_eq!(runtime_map[0].source_start, 50);
+            assert_eq!(runtime_map[0].source_end, 54);
+            assert_eq!(&source[50..54], "0x01");
+
+            // Jump label and jumpi
+            assert_eq!(runtime_map[1].source_start, 59);
+            assert_eq!(runtime_map[1].source_end, 63);
+            assert_eq!(runtime_map[1].length, 6);
+            assert_eq!(&source[59..63], "skip");
+
+            // After jumpi
+            assert_eq!(runtime_map[2].source_start, 64);
+            assert_eq!(runtime_map[2].source_end, 69);
+            assert_eq!(&source[64..69], "jumpi");
+
+            // "0x02"
+            assert_eq!(runtime_map[3].source_start, 74);
+            assert_eq!(runtime_map[3].source_end, 78);
+            assert_eq!(&source[74..78], "0x02");
+
+            // Label "skip:" generates a JUMPDEST
+            assert_eq!(runtime_map[4].source_start, 83);
+            assert_eq!(runtime_map[4].source_end, 87);
+            assert_eq!(runtime_map[4].length, 2);
+            assert_eq!(&source[83..87], "skip");
+
+            // "0x03"
+            assert_eq!(runtime_map[5].source_start, 97);
+            assert_eq!(runtime_map[5].source_end, 101);
+            assert_eq!(&source[97..101], "0x03");
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}
+
+#[test]
+fn test_builtin_functions_source_map() {
+    let source = r#"#define function transfer(address,uint256) nonpayable returns ()
+#define event Transfer(address,address,uint256)
+
+#define macro EMIT_TRANSFER() = takes(3) returns (0) {
+    __EVENT_HASH(Transfer)
+    0x00 0x00
+    log3
+}
+
+#define macro MAIN() = takes(0) returns (0) {
+    0x00 calldataload 0xE0 shr
+    
+    __FUNC_SIG(transfer) eq transfer_fn jumpi
+    
+    0x00 0x00 revert
+    
+    transfer_fn:
+        0x04 calldataload
+        0x24 calldataload
+        caller
+        EMIT_TRANSFER()
+        stop
+}"#;
+
+    let full_source =
+        FileSource { source: Some(source.to_string()), path: "builtins.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler = Compiler::new(&evm_version, Arc::new(vec!["builtins.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(full_source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+            assert!(!runtime_map.is_empty());
+
+            // Should have entries for builtin function expansions
+            assert!(runtime_map.len() > 10);
+
+            // Verify all entries have valid source positions
+            for entry in &runtime_map {
+                assert!(entry.source_end >= entry.source_start);
+                assert!(entry.length > 0);
+            }
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}
+
+#[test]
+fn test_empty_constructor_source_map() {
+    let source = r#"#define macro MAIN() = takes(0) returns (0) {
+    0x42
+    0x00
+    sstore
+    stop
+}"#;
+
+    let full_source =
+        FileSource { source: Some(source.to_string()), path: "no_constructor.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler =
+        Compiler::new(&evm_version, Arc::new(vec!["no_constructor.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(full_source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            // No CONSTRUCTOR macro = no constructor map
+            assert!(artifact.constructor_map.is_none() || artifact.constructor_map.as_ref().unwrap().is_empty());
+
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+            assert_eq!(runtime_map.len(), 4);
+
+            // Verify each entry
+            assert_eq!(runtime_map[0].source_start, 50);
+            assert_eq!(runtime_map[0].source_end, 54);
+            assert_eq!(&source[50..54], "0x42");
+
+            assert_eq!(runtime_map[1].source_start, 59);
+            assert_eq!(runtime_map[1].source_end, 63);
+            assert_eq!(&source[59..63], "0x00");
+
+            assert_eq!(runtime_map[2].source_start, 68);
+            assert_eq!(runtime_map[2].source_end, 74);
+            assert_eq!(&source[68..74], "sstore");
+
+            assert_eq!(runtime_map[3].source_start, 79);
+            assert_eq!(runtime_map[3].source_end, 83);
+            assert_eq!(&source[79..83], "stop");
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}
+
+#[test]
+fn test_source_map_with_flattened_content() {
+    // Simulate a flattened file where imports have been resolved
+    let flattened_content = r#"// From lib.huff
+#define macro ADD_TWO() = takes(2) returns (1) {
+    add
+}
+
+#define macro MUL_TWO() = takes(2) returns (1) {
+    mul
+}
+
+// From main.huff
+#define macro CONSTRUCTOR() = takes(0) returns (0) {
+    0x42
+    0x00
+    sstore
+}
+
+#define macro MAIN() = takes(0) returns (0) {
+    0x01
+    0x02
+    ADD_TWO()
+    0x03
+    MUL_TWO()
+}"#;
+
+    let source =
+        FileSource { source: Some(flattened_content.to_string()), path: "main.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler = Compiler::new(&evm_version, Arc::new(vec!["main.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            // Check constructor map
+            assert!(artifact.constructor_map.is_some());
+            let constructor_map = artifact.constructor_map.unwrap();
+            assert!(!constructor_map.is_empty());
+
+            // Check runtime map
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+            assert_eq!(runtime_map.len(), 5);
+
+            // Verify sequential byte offsets
+            let mut expected_offset = 0;
+            for entry in &runtime_map {
+                assert_eq!(entry.byte_offset, expected_offset);
+                expected_offset += entry.length;
+            }
+
+            // Check that macro expansions point to definitions
+            // "add" should be from ADD_TWO definition
+            assert_eq!(runtime_map[2].source_start, 70);
+            assert_eq!(runtime_map[2].source_end, 73);
+            assert_eq!(&flattened_content[70..73], "add");
+
+            // "mul" should be from MUL_TWO definition
+            assert_eq!(runtime_map[4].source_start, 130);
+            assert_eq!(runtime_map[4].source_end, 133);
+            assert_eq!(&flattened_content[130..133], "mul");
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}
+
+#[test]
+fn test_source_map_complex_nesting() {
+    let complex_content = r#"#define macro INNER() = takes(0) returns (1) {
+    0x42
+}
+
+#define macro MIDDLE() = takes(0) returns (1) {
+    INNER()
+    0x01
+    add
+}
+
+#define macro OUTER() = takes(0) returns (1) {
+    MIDDLE()
+    0x02
+    mul
+}
+
+#define macro MAIN() = takes(0) returns (0) {
+    OUTER()
+    0x00
+    mstore
+    0x20
+    0x00
+    return
+}"#;
+
+    let source =
+        FileSource { source: Some(complex_content.to_string()), path: "complex.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler = Compiler::new(&evm_version, Arc::new(vec!["complex.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+            assert!(runtime_map.len() >= 9);
+
+            // Verify sequential byte offsets
+            let mut expected_offset = 0;
+            for entry in &runtime_map {
+                assert_eq!(entry.byte_offset, expected_offset);
+                expected_offset += entry.length;
+            }
+
+            // Check specific opcode positions from nested macros
+            // "0x42" from INNER
+            assert_eq!(runtime_map[0].source_start, 51);
+            assert_eq!(runtime_map[0].source_end, 55);
+            assert_eq!(&complex_content[51..55], "0x42");
+
+            // "0x01" from MIDDLE
+            assert_eq!(runtime_map[1].source_start, 123);
+            assert_eq!(runtime_map[1].source_end, 127);
+            assert_eq!(&complex_content[123..127], "0x01");
+
+            // "add" from MIDDLE
+            assert_eq!(runtime_map[2].source_start, 132);
+            assert_eq!(runtime_map[2].source_end, 135);
+            assert_eq!(&complex_content[132..135], "add");
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}
+
+#[test]
+fn test_source_map_points_to_actual_opcodes_not_invocations() {
+    let source = r#"#define macro STORE_ONE() = takes(0) returns (0) {
+    0x01
+    0x00
+    sstore
+}
+
+#define macro LOAD_ZERO() = takes(0) returns (1) {
+    0x00
+    sload
+}
+
+#define macro COMPLEX() = takes(0) returns (0) {
+    STORE_ONE()
+    LOAD_ZERO()
+    pop
+}
+
+#define macro MAIN() = takes(0) returns (0) {
+    COMPLEX()
+    stop
+}"#;
+
+    let full_source = FileSource { source: Some(source.to_string()), path: "test.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler = Compiler::new(&evm_version, Arc::new(vec!["test.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(full_source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+
+            // Verify exact positions map to actual opcodes, not invocations
+            // "0x01" from STORE_ONE
+            assert_eq!(runtime_map[0].source_start, 55);
+            assert_eq!(runtime_map[0].source_end, 59);
+            assert_eq!(&source[55..59], "0x01");
+
+            // "0x00" from STORE_ONE
+            assert_eq!(runtime_map[1].source_start, 64);
+            assert_eq!(runtime_map[1].source_end, 68);
+            assert_eq!(&source[64..68], "0x00");
+
+            // "sstore" from STORE_ONE
+            assert_eq!(runtime_map[2].source_start, 73);
+            assert_eq!(runtime_map[2].source_end, 79);
+            assert_eq!(&source[73..79], "sstore");
+
+            // "0x00" from LOAD_ZERO
+            assert_eq!(runtime_map[3].source_start, 138);
+            assert_eq!(runtime_map[3].source_end, 142);
+            assert_eq!(&source[138..142], "0x00");
+
+            // "sload" from LOAD_ZERO
+            assert_eq!(runtime_map[4].source_start, 147);
+            assert_eq!(runtime_map[4].source_end, 152);
+            assert_eq!(&source[147..152], "sload");
+
+            // "pop" from COMPLEX
+            assert_eq!(runtime_map[5].source_start, 241);
+            assert_eq!(runtime_map[5].source_end, 244);
+            assert_eq!(&source[241..244], "pop");
+
+            // "stop" from MAIN
+            assert_eq!(runtime_map[6].source_start, 312);
+            assert_eq!(runtime_map[6].source_end, 316);
+            assert_eq!(&source[312..316], "stop");
+
+            // Verify we don't have entries pointing to macro invocations
+            // STORE_ONE() is at 217-226, LOAD_ZERO() at 232-242, COMPLEX() at 277-285
+            for entry in &runtime_map {
+                assert!(!(entry.source_start == 217 && entry.source_end == 226));
+                assert!(!(entry.source_start == 232 && entry.source_end == 242));
+                assert!(!(entry.source_start == 277 && entry.source_end == 285));
+            }
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}
+
+#[test]
+fn test_source_map_with_macro_arguments() {
+    let source = r#"#define macro ADD_CONST(const) = takes(1) returns (1) {
+    <const>
+    add
+}
+
+#define macro MUL_CONST(const) = takes(1) returns (1) {
+    <const>
+    mul
+}
+
+#define macro MAIN() = takes(0) returns (0) {
+    0x05
+    0x03
+    ADD_CONST(0x02)
+    MUL_CONST(0x04)
+    0x00
+    mstore
+}"#;
+
+    let full_source = FileSource { source: Some(source.to_string()), path: "test.huff".to_string(), access: None, dependencies: vec![] };
+
+    let evm_version = EVMVersion::default();
+    let compiler = Compiler::new(&evm_version, Arc::new(vec!["test.huff".to_string()]), None, None, None, None, None, false, false);
+
+    let arc_source = Arc::new(full_source);
+    match compiler.gen_artifact(Arc::clone(&arc_source)) {
+        Ok(artifact) => {
+            assert!(artifact.runtime_map.is_some());
+            let runtime_map = artifact.runtime_map.unwrap();
+
+            // Check exact positions and content
+            // "0x05" from MAIN
+            assert_eq!(runtime_map[0].source_start, 208);
+            assert_eq!(runtime_map[0].source_end, 212);
+            assert_eq!(&source[208..212], "0x05");
+
+            // "0x03" from MAIN
+            assert_eq!(runtime_map[1].source_start, 217);
+            assert_eq!(runtime_map[1].source_end, 221);
+            assert_eq!(&source[217..221], "0x03");
+
+            // "<const>" placeholder from ADD_CONST
+            assert_eq!(runtime_map[2].source_start, 60);
+            assert_eq!(runtime_map[2].source_end, 67);
+            assert_eq!(&source[60..67], "<const>");
+
+            // "add" from ADD_CONST definition
+            assert_eq!(runtime_map[3].source_start, 72);
+            assert_eq!(runtime_map[3].source_end, 75);
+            assert_eq!(&source[72..75], "add");
+
+            // "<const>" placeholder from MUL_CONST
+            assert_eq!(runtime_map[4].source_start, 139);
+            assert_eq!(runtime_map[4].source_end, 146);
+            assert_eq!(&source[139..146], "<const>");
+
+            // "mul" from MUL_CONST definition
+            assert_eq!(runtime_map[5].source_start, 151);
+            assert_eq!(runtime_map[5].source_end, 154);
+            assert_eq!(&source[151..154], "mul");
+
+            // "0x00" from MAIN
+            assert_eq!(runtime_map[6].source_start, 266);
+            assert_eq!(runtime_map[6].source_end, 270);
+            assert_eq!(&source[266..270], "0x00");
+
+            // "mstore" from MAIN
+            assert_eq!(runtime_map[7].source_start, 275);
+            assert_eq!(runtime_map[7].source_end, 281);
+            assert_eq!(&source[275..281], "mstore");
+
+            // Verify sequential byte offsets
+            let mut expected_offset = 0;
+            for entry in &runtime_map {
+                assert_eq!(entry.byte_offset, expected_offset);
+                expected_offset += entry.length;
+            }
+        }
+        Err(e) => panic!("Failed to generate artifact: {}", e),
+    }
+}

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1318,14 +1318,18 @@ impl Parser {
 
     /// Parses a constant push.
     pub fn parse_constant_push(&mut self) -> Result<(String, Span), ParserError> {
+        // Save the opening bracket span to include it in the constant reference span
+        let start_span = self.current_token.span.clone();
         self.match_kind(TokenKind::OpenBracket)?;
         match self.current_token.kind.clone() {
             TokenKind::Ident(const_str) => {
                 // Consume the Ident and Validate Close Bracket
-                let iden_span = self.current_token.span.clone();
                 self.consume();
+                let end_span = self.current_token.span.clone();
                 self.match_kind(TokenKind::CloseBracket)?;
-                Ok((const_str, iden_span))
+                // Create a span that includes [VAL] from opening bracket to closing bracket
+                let full_span = Span { start: start_span.start, end: end_span.end, file: start_span.file };
+                Ok((const_str, full_span))
             }
             kind => {
                 let new_spans = self.spans.clone();
@@ -1352,13 +1356,17 @@ impl Parser {
     /// }
     /// ```
     pub fn parse_arg_call(&mut self) -> Result<(String, Span), ParserError> {
+        // Save the opening angle bracket span to include it in the arg call span
+        let start_span = self.current_token.span.clone();
         self.match_kind(TokenKind::LeftAngle)?;
         match self.current_token.kind.clone() {
             TokenKind::Ident(arg_str) => {
-                let arg_call_span = self.current_token.span.clone();
                 self.consume();
+                let end_span = self.current_token.span.clone();
                 self.match_kind(TokenKind::RightAngle)?;
-                Ok((arg_str, arg_call_span))
+                // Create a span that includes <arg> from opening angle to closing angle
+                let full_span = Span { start: start_span.start, end: end_span.end, file: start_span.file };
+                Ok((arg_str, full_span))
             }
             kind => {
                 let new_spans = self.spans.clone();

--- a/crates/parser/tests/macro.rs
+++ b/crates/parser/tests/macro.rs
@@ -250,7 +250,7 @@ fn macro_with_arg_calls() {
             Statement { ty: StatementType::Opcode(Opcode::Dup2), span: AstSpan(vec![Span { start: 209, end: 213, file: None }]) },
             Statement {
                 ty: StatementType::Constant("BALANCE_LOCATION".to_string()),
-                span: AstSpan(vec![Span { start: 265, end: 281, file: None }]),
+                span: AstSpan(vec![Span { start: 264, end: 282, file: None }]),
             },
             Statement {
                 ty: StatementType::MacroInvocation(MacroInvocation {
@@ -275,7 +275,7 @@ fn macro_with_arg_calls() {
             Statement { ty: StatementType::Opcode(Opcode::Gt), span: AstSpan(vec![Span { start: 492, end: 494, file: None }]) },
             Statement {
                 ty: StatementType::ArgCall("TRANSFER_TAKE_FROM".to_string(), "error".to_string()),
-                span: AstSpan(vec![Span { start: 566, end: 571, file: None }]),
+                span: AstSpan(vec![Span { start: 565, end: 572, file: None }]),
             },
             Statement { ty: StatementType::Opcode(Opcode::Jumpi), span: AstSpan(vec![Span { start: 573, end: 578, file: None }]) },
             Statement { ty: StatementType::Opcode(Opcode::Dup2), span: AstSpan(vec![Span { start: 715, end: 719, file: None }]) },
@@ -284,7 +284,7 @@ fn macro_with_arg_calls() {
             Statement { ty: StatementType::Opcode(Opcode::Dup3), span: AstSpan(vec![Span { start: 911, end: 915, file: None }]) },
             Statement {
                 ty: StatementType::Constant("BALANCE_LOCATION".to_string()),
-                span: AstSpan(vec![Span { start: 982, end: 998, file: None }]),
+                span: AstSpan(vec![Span { start: 981, end: 999, file: None }]),
             },
             Statement {
                 ty: StatementType::MacroInvocation(MacroInvocation {


### PR DESCRIPTION
- Standardize span convention to use exclusive end positions (following Rust Range convention).
  - All spans now use `start..end` where `end` is exclusive (points after the last character).
- Fix source mapping to correctly handle nested macro expansions.
  - Spans now point to actual opcodes in macro definitions, not invocations.