### PR TITLE
feat: add option to output flattened source code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+- Add `--flattened-source` CLI flag to output the flattened source code (with all includes resolved).
 
 ## [1.3.2] - 2025-08-14
 - Standardize span convention to use exclusive end positions (following Rust Range convention).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Huff Neo is a production-ready compiler for the Huff language - a low-level programming language for developing highly optimized smart contracts that compile to EVM bytecode. This is a maintained fork of the archived huff-rs repository.
 
+## Code Organization Requirements
+
+### Import Statements
+- **MUST**: All `use` statements must be placed at the top of the file with the other imports
+- **NEVER**: Place `use` statements inside functions or methods
+- This ensures consistency, makes dependencies clear at a glance, and improves compilation performance
+
 ## Build and Development Commands
 
 ### Essential Commands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4085,6 +4085,7 @@ dependencies = [
  "huff-neo-utils",
  "rand 0.9.2",
  "rayon",
+ "regex",
  "serde_json",
  "tracing",
  "tracing-subscriber 0.3.19",

--- a/bin/hnc/src/arguments/base.rs
+++ b/bin/hnc/src/arguments/base.rs
@@ -85,13 +85,13 @@ pub struct HuffArgs {
     #[clap(subcommand)]
     pub test: Option<TestCommands>,
 
+    /// Output the flattened source code with all dependencies resolved
+    #[clap(long = "flattened-source")]
+    pub flattened_source: bool,
+
     /// Print version
     #[arg(short = 'V', long = "version")]
     pub version_long: bool,
-
-    /// Output the flattened source code
-    #[clap(long = "flattened-source")]
-    pub flattened_source: bool,
 }
 
 #[derive(Subcommand, Clone, Debug)]

--- a/bin/hnc/src/arguments/base.rs
+++ b/bin/hnc/src/arguments/base.rs
@@ -88,6 +88,10 @@ pub struct HuffArgs {
     /// Print version
     #[arg(short = 'V', long = "version")]
     pub version_long: bool,
+
+    /// Output the flattened source code
+    #[clap(long = "flattened-source")]
+    pub flattened_source: bool,
 }
 
 #[derive(Subcommand, Clone, Debug)]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,6 +19,7 @@ huff-neo-utils.workspace = true
 
 alloy-dyn-abi.workspace = true
 alloy-primitives.workspace = true
+regex.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/core/tests/flattened_source.rs
+++ b/crates/core/tests/flattened_source.rs
@@ -1,0 +1,166 @@
+use huff_neo_core::Compiler;
+use huff_neo_utils::file::file_provider::InMemoryFileProvider;
+use huff_neo_utils::file::file_source::FileSource;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[test]
+fn test_flattened_source_removes_includes() {
+    // Create a simple contract with includes
+    let mut file_sources = HashMap::new();
+
+    // Main file with includes
+    file_sources.insert(
+        "./main.huff".to_string(),
+        r#"#include "./constants.huff"
+#include "./macros.huff"
+
+#define macro MAIN() = takes(0) returns(0) {
+    0x00 0x00 revert
+}"#
+        .to_string(),
+    );
+
+    // Constants file
+    file_sources
+        .insert("./constants.huff".to_string(), r#"#define constant OWNER = 0x1234567890123456789012345678901234567890"#.to_string());
+
+    // Macros file
+    file_sources.insert(
+        "./macros.huff".to_string(),
+        r#"#define macro ADD() = takes(2) returns(1) {
+    add
+}"#
+        .to_string(),
+    );
+
+    let file_provider = Arc::new(InMemoryFileProvider::new(file_sources));
+
+    // Create a FileSource for the main file
+    let main_file = Arc::new(FileSource {
+        path: "./main.huff".to_string(),
+        source: Some(
+            r#"#include "./constants.huff"
+#include "./macros.huff"
+
+#define macro MAIN() = takes(0) returns(0) {
+    0x00 0x00 revert
+}"#
+            .to_string(),
+        ),
+        access: None,
+        dependencies: vec![],
+    });
+
+    // Get flattened source
+    let result = Compiler::get_flattened_source(main_file, file_provider);
+
+    assert!(result.is_ok());
+    let flattened = result.unwrap();
+
+    // Check that #include statements are commented out
+    assert!(flattened.contains("// #include"));
+    assert!(!flattened.contains("\n#include")); // No uncommented includes
+
+    // Check that the actual content from included files is present
+    assert!(flattened.contains("#define constant OWNER"));
+    assert!(flattened.contains("#define macro ADD()"));
+    assert!(flattened.contains("#define macro MAIN()"));
+}
+
+#[test]
+fn test_flattened_source_handles_inline_includes() {
+    // Test case where #include appears on same line as other content
+    let mut file_sources = HashMap::new();
+
+    file_sources.insert(
+        "./main.huff".to_string(),
+        r#"#define macro FOO() = takes(0) returns(0) {
+    0x00
+}#include "./other.huff"
+#define macro BAR() = takes(0) returns(0) {
+    0x01
+}"#
+        .to_string(),
+    );
+
+    file_sources.insert("./other.huff".to_string(), r#"#define constant VALUE = 0x42"#.to_string());
+
+    let file_provider = Arc::new(InMemoryFileProvider::new(file_sources));
+
+    let main_file = Arc::new(FileSource {
+        path: "./main.huff".to_string(),
+        source: Some(
+            r#"#define macro FOO() = takes(0) returns(0) {
+    0x00
+}#include "./other.huff"
+#define macro BAR() = takes(0) returns(0) {
+    0x01
+}"#
+            .to_string(),
+        ),
+        access: None,
+        dependencies: vec![],
+    });
+
+    let result = Compiler::get_flattened_source(main_file, file_provider);
+
+    assert!(result.is_ok());
+    let flattened = result.unwrap();
+
+    // Check that #include is commented out even when it's on the same line as other content
+    assert!(flattened.contains("// #include"));
+    assert!(!flattened.contains("}#include")); // The problematic case should be fixed
+
+    // The closing brace should still be there
+    assert!(flattened.contains("}"));
+    assert!(flattened.contains("#define constant VALUE"));
+}
+
+#[test]
+fn test_flattened_source_preserves_non_include_directives() {
+    // Test that other preprocessor directives are preserved
+    let mut file_sources = HashMap::new();
+
+    file_sources.insert(
+        "./main.huff".to_string(),
+        r#"#include "./helper.huff"
+#define macro MAIN() = takes(0) returns(0) {
+    #define constant LOCAL = 0x01
+    0x00 0x00 revert
+}"#
+        .to_string(),
+    );
+
+    file_sources.insert("./helper.huff".to_string(), r#"#define function transfer(address,uint256) nonpayable returns()"#.to_string());
+
+    let file_provider = Arc::new(InMemoryFileProvider::new(file_sources));
+
+    let main_file = Arc::new(FileSource {
+        path: "./main.huff".to_string(),
+        source: Some(
+            r#"#include "./helper.huff"
+#define macro MAIN() = takes(0) returns(0) {
+    #define constant LOCAL = 0x01
+    0x00 0x00 revert
+}"#
+            .to_string(),
+        ),
+        access: None,
+        dependencies: vec![],
+    });
+
+    let result = Compiler::get_flattened_source(main_file, file_provider);
+
+    assert!(result.is_ok());
+    let flattened = result.unwrap();
+
+    // #include should be commented out
+    assert!(flattened.contains("// #include"));
+    assert!(!flattened.contains("\n#include")); // No uncommented includes on new lines
+
+    // But other #define directives should be preserved
+    assert!(flattened.contains("#define macro MAIN()"));
+    assert!(flattened.contains("#define constant LOCAL"));
+    assert!(flattened.contains("#define function transfer"));
+}

--- a/crates/utils/src/file/file_source.rs
+++ b/crates/utils/src/file/file_source.rs
@@ -57,6 +57,8 @@ impl FileSource {
     /// Let's say you have a file, `a.txt` with two dependencies, `b.txt` and `c.txt`,
     /// `fully_flatten()` will generate a source code string with the contents of `b.txt` and
     /// `c.txt` appended to the end of the contents of `a.txt`.
+    ///
+    /// Note: This preserves #include statements in the output to maintain correct span positions
     pub fn fully_flatten(node_file_source: Arc<FileSource>) -> (String, Vec<(Arc<FileSource>, Span)>) {
         let all_file_sources = FileSource::discover_all_file_sources(node_file_source, &mut HashSet::new());
 

--- a/crates/utils/src/file/file_source.rs
+++ b/crates/utils/src/file/file_source.rs
@@ -65,10 +65,17 @@ impl FileSource {
         let mut shift_pos = 0;
 
         // Append all child elements
-        for child_file_source in all_file_sources {
+        for (i, child_file_source) in all_file_sources.into_iter().enumerate() {
             let Some(source) = child_file_source.source.clone() else {
                 continue;
             };
+
+            // Add a newline before each file after the first to ensure proper separation
+            if i > 0 && !full_source.ends_with('\n') {
+                full_source.push('\n');
+                shift_pos += 1;
+            }
+
             let span = Span::new(shift_pos..(shift_pos + source.len() - 1), Some(child_file_source.clone()));
             relative_positions.push((child_file_source, span));
             shift_pos += source.len();

--- a/crates/utils/tests/file_source.rs
+++ b/crates/utils/tests/file_source.rs
@@ -1,4 +1,3 @@
-use huff_neo_utils::file::file_source;
 use huff_neo_utils::file::file_source::FileSource;
 use huff_neo_utils::prelude::Span;
 use huff_neo_utils::time::Time;
@@ -36,20 +35,20 @@ fn test_fully_flatten() {
 
     let (flattened_source, relative_positions) = FileSource::fully_flatten(file_a_with_deps);
 
-    assert_eq!(flattened_source, "content of d content of b content of c content of a ");
+    assert_eq!(flattened_source, "content of d \ncontent of b \ncontent of c \ncontent of a ");
     assert_eq!(relative_positions.len(), 4);
 
     assert_eq!(relative_positions.first().unwrap().1.start, 0);
     assert_eq!(relative_positions.first().unwrap().1.end, 12);
 
-    assert_eq!(relative_positions.get(1).unwrap().1.start, 13);
-    assert_eq!(relative_positions.get(1).unwrap().1.end, 25);
+    assert_eq!(relative_positions.get(1).unwrap().1.start, 14);
+    assert_eq!(relative_positions.get(1).unwrap().1.end, 26);
 
-    assert_eq!(relative_positions.get(2).unwrap().1.start, 26);
-    assert_eq!(relative_positions.get(2).unwrap().1.end, 38);
+    assert_eq!(relative_positions.get(2).unwrap().1.start, 28);
+    assert_eq!(relative_positions.get(2).unwrap().1.end, 40);
 
-    assert_eq!(relative_positions.get(3).unwrap().1.start, 39);
-    assert_eq!(relative_positions.get(3).unwrap().1.end, 51);
+    assert_eq!(relative_positions.get(3).unwrap().1.start, 42);
+    assert_eq!(relative_positions.get(3).unwrap().1.end, 54);
 }
 
 #[test]
@@ -58,12 +57,12 @@ fn test_source_seg() {
         start: 59,
         end: 67,
         file: Some(Arc::new(
-            file_source::FileSource {
+            FileSource {
                 path: "./huff-examples/errors/error.huff".to_string(),
                 source: Some("#include \"./import.huff\"\n\n#define function addressGetter() internal returns (address)".to_string()),
                 access: None,
                 dependencies: vec![
-                    Arc::new(file_source::FileSource {
+                    Arc::new(FileSource {
                         path: "./huff-examples/errors/import.huff".to_string(),
                         source: Some("#define macro SOME_RANDOM_MACRO() = takes(2) returns (1) {\n    // Store the keys in memory\n    dup1 0x00 mstore\n    swap1 dup1 0x00 mstore\n\n    // Hash the data, generating a key.\n    0x40 sha3\n}\n".to_string()),
                         access: None,
@@ -83,48 +82,48 @@ fn test_source_seg() {
 
 #[test]
 fn test_derive_dir() {
-    let localized = file_source::FileSource::derive_dir("./examples/ERC20.huff").unwrap();
+    let localized = FileSource::derive_dir("./examples/ERC20.huff").unwrap();
     assert_eq!(localized, "./examples");
-    let localized = file_source::FileSource::derive_dir("./ERC20.huff").unwrap();
+    let localized = FileSource::derive_dir("./ERC20.huff").unwrap();
     assert_eq!(localized, ".");
-    let localized = file_source::FileSource::derive_dir("ERC20.huff").unwrap();
+    let localized = FileSource::derive_dir("ERC20.huff").unwrap();
     assert_eq!(localized, "");
 }
 
 #[test]
 fn test_localize_file() {
-    let localized = file_source::FileSource::localize_file("./examples/ERC20.huff", "./utilities/Address.huff").unwrap();
+    let localized = FileSource::localize_file("./examples/ERC20.huff", "./utilities/Address.huff").unwrap();
     assert_eq!(localized, "./examples/utilities/Address.huff");
-    let localized = file_source::FileSource::localize_file("./ERC20.huff", "./utilities/Address.huff").unwrap();
+    let localized = FileSource::localize_file("./ERC20.huff", "./utilities/Address.huff").unwrap();
     assert_eq!(localized, "./utilities/Address.huff");
-    let localized = file_source::FileSource::localize_file("ERC20.huff", "./utilities/Address.huff").unwrap();
+    let localized = FileSource::localize_file("ERC20.huff", "./utilities/Address.huff").unwrap();
     assert_eq!(localized, "./utilities/Address.huff");
-    let localized = file_source::FileSource::localize_file("ERC20.huff", "./Address.huff").unwrap();
+    let localized = FileSource::localize_file("ERC20.huff", "./Address.huff").unwrap();
     assert_eq!(localized, "./Address.huff");
-    let localized = file_source::FileSource::localize_file("ERC20.huff", "Address.huff").unwrap();
+    let localized = FileSource::localize_file("ERC20.huff", "Address.huff").unwrap();
     assert_eq!(localized, "./Address.huff");
-    let localized = file_source::FileSource::localize_file("./ERC20.huff", "Address.huff").unwrap();
+    let localized = FileSource::localize_file("./ERC20.huff", "Address.huff").unwrap();
     assert_eq!(localized, "./Address.huff");
-    let localized = file_source::FileSource::localize_file("./examples/ERC20.huff", "Address.huff").unwrap();
+    let localized = FileSource::localize_file("./examples/ERC20.huff", "Address.huff").unwrap();
     assert_eq!(localized, "./examples/Address.huff");
-    let localized = file_source::FileSource::localize_file("./examples/ERC20.huff", "../Address.huff").unwrap();
+    let localized = FileSource::localize_file("./examples/ERC20.huff", "../Address.huff").unwrap();
     assert_eq!(localized, "./Address.huff");
-    let localized = file_source::FileSource::localize_file("./examples/ERC20.huff", "../../Address.huff").unwrap();
+    let localized = FileSource::localize_file("./examples/ERC20.huff", "../../Address.huff").unwrap();
     assert_eq!(localized, "../Address.huff");
-    let localized = file_source::FileSource::localize_file("./examples/ERC20.huff", "../../../Address.huff").unwrap();
+    let localized = FileSource::localize_file("./examples/ERC20.huff", "../../../Address.huff").unwrap();
     assert_eq!(localized, "../../Address.huff");
-    let localized = file_source::FileSource::localize_file("../examples/ERC20.huff", "../../../Address.huff").unwrap();
+    let localized = FileSource::localize_file("../examples/ERC20.huff", "../../../Address.huff").unwrap();
     assert_eq!(localized, "../../../Address.huff");
-    let localized = file_source::FileSource::localize_file("../examples/ERC20.huff", "./Address.huff").unwrap();
+    let localized = FileSource::localize_file("../examples/ERC20.huff", "./Address.huff").unwrap();
     assert_eq!(localized, "../examples/Address.huff");
-    let localized = file_source::FileSource::localize_file("../examples/ERC20.huff", "Address.huff").unwrap();
+    let localized = FileSource::localize_file("../examples/ERC20.huff", "Address.huff").unwrap();
     assert_eq!(localized, "../examples/Address.huff");
-    let localized = file_source::FileSource::localize_file("../../examples/ERC20.huff", "Address.huff").unwrap();
+    let localized = FileSource::localize_file("../../examples/ERC20.huff", "Address.huff").unwrap();
     assert_eq!(localized, "../../examples/Address.huff");
-    let localized = file_source::FileSource::localize_file("../../examples/ERC20.huff", "../Address.huff").unwrap();
+    let localized = FileSource::localize_file("../../examples/ERC20.huff", "../Address.huff").unwrap();
     assert_eq!(localized, "../../Address.huff");
-    let localized = file_source::FileSource::localize_file("../../examples/ERC20.huff", "../../../Address.huff").unwrap();
+    let localized = FileSource::localize_file("../../examples/ERC20.huff", "../../../Address.huff").unwrap();
     assert_eq!(localized, "../../../../Address.huff");
-    let localized = file_source::FileSource::localize_file("examples/ERC20.huff", "../random_dir/Address.huff").unwrap();
+    let localized = FileSource::localize_file("examples/ERC20.huff", "../random_dir/Address.huff").unwrap();
     assert_eq!(localized, "./random_dir/Address.huff");
 }


### PR DESCRIPTION
- Add `--flattened-source` CLI flag to output the flattened source code (with all includes resolved).