### PR TITLE
chore: add proper types for TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 - Add `--flattened-source` CLI flag to output the flattened source code (with all includes resolved).
 - Add source code display in debugger with proper multi-file support.
+- Improve TypeScript definitions for WASM/JS package with proper types instead of `any`.
 
 ## [1.3.2] - 2025-08-14
 - Standardize span convention to use exclusive end positions (following Rust Range convention).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3858,6 +3858,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "gmp-mpfr-sys"
 version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4100,6 +4113,8 @@ dependencies = [
  "huff-neo-utils",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
+ "tsify",
  "wasm-bindgen",
 ]
 
@@ -4170,6 +4185,8 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber 0.3.19",
+ "tsify",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6918,6 +6935,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "serde_fmt"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8158,6 +8186,32 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tsify"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ec91b85e6c6592ed28636cb1dd1fac377ecbbeb170ff1d79f97aac5e38926d"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a324606929ad11628a19206d7853807481dcaecd6c08be70a235930b8241955"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ serde_json = "1.0.142"
 strum = "0.27.2"
 strum_macros = "0.27.2"
 toml = { version = "0.8.23", default-features = false, features = ["parse"] }
+tsify = { version = "0.5.5", features = ["js"] }
 
 # dev
 criterion = "0.6.0"

--- a/crates/js/Cargo.toml
+++ b/crates/js/Cargo.toml
@@ -16,10 +16,12 @@ crate-type = ["cdylib"]
 
 [dependencies]
 huff-neo-core.workspace = true
-huff-neo-utils.workspace = true
+huff-neo-utils = { workspace = true, features = ["wasm"] }
 
 serde.workspace = true
+serde_json.workspace = true
 serde-wasm-bindgen.workspace = true
+tsify.workspace = true
 wasm-bindgen.workspace = true
 
 [dev-dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -27,6 +27,12 @@ strum_macros.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tsify = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys.workspace = true
+
+[features]
+default = []
+wasm = ["dep:tsify", "dep:wasm-bindgen"]

--- a/crates/utils/src/abi.rs
+++ b/crates/utils/src/abi.rs
@@ -53,14 +53,19 @@ use std::{collections::BTreeMap, fmt};
 ///
 /// The ABI of the generated code.
 #[derive(Default, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Abi {
     /// The constructor
     pub constructor: Option<Constructor>,
     /// A list of functions and their definitions
+    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, Function>"))]
     pub functions: BTreeMap<String, Function>,
     /// A list of events and their definitions
+    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, Event>"))]
     pub events: BTreeMap<String, Event>,
     /// A list of errors and their definitions
+    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, Error>"))]
     pub errors: BTreeMap<String, Error>,
     /// If the contract defines receive logic
     pub receive: bool,
@@ -69,7 +74,7 @@ pub struct Abi {
 }
 
 impl Abi {
-    /// Public associated function to instatiate a new Abi.
+    /// Public associated function to instantiate a new Abi.
     pub fn new() -> Self {
         Self::default()
     }
@@ -78,7 +83,7 @@ impl Abi {
 // Allows for simple ABI Generation by directly translating the AST
 impl From<huff::Contract> for Abi {
     fn from(contract: huff::Contract) -> Self {
-        // Try to get the constructor inputs from an overriden function
+        // Try to get the constructor inputs from an overridden function
         // Otherwise, use the CONSTRUCTOR macro if one exists
         let constructor = contract
             .functions
@@ -197,6 +202,8 @@ impl From<huff::Contract> for Abi {
 ///
 /// A function definition.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Function {
     /// The function name
     pub name: String,
@@ -214,6 +221,8 @@ pub struct Function {
 ///
 /// An Event definition.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Event {
     /// The event name
     pub name: String,
@@ -227,6 +236,8 @@ pub struct Event {
 ///
 /// Event parameters.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct EventParam {
     /// The parameter name
     pub name: String,
@@ -240,6 +251,8 @@ pub struct EventParam {
 ///
 /// An Error definition.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Error {
     /// The error name
     pub name: String,
@@ -251,8 +264,10 @@ pub struct Error {
 ///
 /// The contract constructor
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Constructor {
-    /// Contstructor inputs
+    /// Constructor inputs
     pub inputs: Vec<FunctionParam>,
 }
 
@@ -260,6 +275,8 @@ pub struct Constructor {
 ///
 /// A generic function parameter
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct FunctionParam {
     /// The function parameter name
     pub name: String,
@@ -271,8 +288,10 @@ pub struct FunctionParam {
 
 /// #### FunctionParamType
 ///
-/// The type of a function parameter
+/// The type of function parameter
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum FunctionParamType {
     /// An address
     Address,

--- a/crates/utils/src/artifact.rs
+++ b/crates/utils/src/artifact.rs
@@ -10,6 +10,8 @@ use crate::file::file_source::FileSource;
 
 /// A bytecode source mapping entry
 #[derive(Default, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct SourceMapEntry {
     /// Instruction Counter (IC) - the instruction index (0, 1, 2, ...)
     /// This is used to index into the source map array

--- a/crates/utils/src/ast/abi.rs
+++ b/crates/utils/src/ast/abi.rs
@@ -48,6 +48,8 @@ pub struct FunctionDefinition {
 
 /// Function Types
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum FunctionType {
     /// Viewable Function
     View,

--- a/crates/utils/src/file/file_source.rs
+++ b/crates/utils/src/file/file_source.rs
@@ -8,12 +8,15 @@ use std::sync::Arc;
 
 /// File Encapsulation
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct FileSource {
     /// File Path
     pub path: String,
     /// File Source
     pub source: Option<String>,
     /// Last File Access Time
+    #[cfg_attr(feature = "wasm", tsify(type = "number | undefined"))]
     pub access: Option<time::Time>,
     /// An Ordered List of File Dependencies
     pub dependencies: Vec<Arc<FileSource>>,


### PR DESCRIPTION
- Improve TypeScript definitions for WASM/JS package with proper types instead of `any`.