### PR TITLE
fix: infinite loop when compiling nested first-class macro invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 - Fix parsing of nested first-class macro argument invocations like `<m>(<a>())` (fixes #96).
+- Fix infinite loop when compiling nested first-class macro invocations by resolving arguments at invocation time (fixes #98).
 
 ## [1.3.5] - 2025-08-23
 - Fix invoking nested first-class macro with parameters (`<arg>()` syntax) (fixes #94).


### PR DESCRIPTION
- Fix infinite loop when compiling nested first-class macro invocations by resolving arguments at invocation time (fixes #98).