### PR TITLE
fix: sibling scope label resolution for nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 - Fix parsing of nested first-class macro argument invocations like `<m>(<a>())` (fixes #96).
 - Fix infinite loop when compiling nested first-class macro invocations by resolving arguments at invocation time (fixes #98).
+- Fix label resolution in sibling scopes when labels are passed through nested macro invocations (fixes #97).
 
 ## [1.3.5] - 2025-08-23
 - Fix invoking nested first-class macro with parameters (`<arg>()` syntax) (fixes #94).

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -621,7 +621,11 @@ impl Codegen {
                         }
                         Ok(None) => {
                             // The jump did not have a corresponding label index. Add it to the unmatched jumps vec.
-                            tracing::warn!(target: "codegen", "UNMATCHED JUMP LABEL \"{}\" AT BYTECODE INDEX {}", jump.label, code_index);
+                            tracing::warn!(
+                                target: "codegen",
+                                "UNMATCHED JUMP LABEL \"{}\" AT BYTECODE INDEX {} (scope_depth={}, scope_path={:?})",
+                                jump.label, code_index, jump.scope_depth, jump.scope_path
+                            );
                             unmatched_jumps.push(Jump {
                                 label: jump.label.clone(),
                                 bytecode_index: code_index,


### PR DESCRIPTION
- Fix label resolution in sibling scopes when labels are passed through nested macro invocations (fixes #97).