### PR TITLE
fix: argument leaking into nested macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+- Fix macro argument scoping to prevent arguments from leaking into nested macros that don't receive them (fixes #108).
 
 ## [1.3.9] - 2025-10-18
 - Add arithmetic support for constants with operators: `+`, `-`, `*`, `/`, `%`, and negation.

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-cargo:
 .PHONY: test-doc
 test-doc:
 	RUSTDOCFLAGS="--show-type-layout --generate-link-to-definition --enable-index-page -D warnings -Z unstable-options" \
-	cargo +nightly test --doc --workspace --all-features
+	cargo +nightly test --doc --workspace --exclude huff-neo-js --all-features
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
- Fix macro argument scoping to prevent arguments from leaking into nested macros that don't receive them (fixes #108).