### PR TITLE
feat: support for for-loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+- Add compile-time for-loops that expand during compilation.
+  - Syntax: `for(variable in start..end) { body }` or `for(variable in start..end step N) { body }`
+  - Support for a loop variable with `<variable>`.
+    - Example: `for(i in 0..5) { <i> }` expands to `0x00 0x01 0x02 0x03 0x04`
 
 ## [1.3.10] - 2025-11-01
 - Fix macro argument scoping to prevent arguments from leaking into nested macros that don't receive them (fixes #108).

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -1,7 +1,7 @@
 # Summary
 - [Getting Started](get-started/getting-started.md)
   - [About Huff](get-started/about-huff.md)
-  - [Comparison to huffc](get-started/comparison-to-huff-rs.md)
+  - [Comparison to huff-rs](get-started/comparison-to-huff-rs.md)
   - [Compile a contract](get-started/compiling.md)
   - [Project Quickstart](get-started/project-quickstart.md)
 - [Huff Language](huff-language/overview.md)
@@ -9,6 +9,7 @@
   - [Builtin Functions](huff-language/builtin-functions.md)
   - [Functions and events](huff-language/functions-and-events.md)
   - [Constants](huff-language/constants.md)
+  - [Compile-Time Loops](huff-language/compile-time-loops.md)
   - [Custom Errors](huff-language/custom-errors.md)
   - [Jump Labels](huff-language/jump-labels.md)
   - [Jump Tables](huff-language/jump-tables.md)

--- a/book/get-started/comparison-to-huff-rs.md
+++ b/book/get-started/comparison-to-huff-rs.md
@@ -69,6 +69,29 @@ Macros can now be passed as arguments to other macros and invoked dynamically, m
 
 See the [Macros and Functions](../huff-language/macros-and-functions.md#first-class-macro-arguments) documentation for more details.
 
+### Compile-time for loops
+Generate repetitive code patterns at compile-time using for loops that expand before bytecode generation.
+
+```javascript
+#define constant COUNT = 10
+
+#define macro INIT_STORAGE() = takes(0) returns(0) {
+    // Initialize storage slots 0 through 9 with zero
+    for(i in 0..COUNT) {
+        0x00 <i> sstore
+    }
+}
+
+#define macro PUSH_SEQUENCE() = takes(0) returns(5) {
+    // Generate: 0x00 0x02 0x04 0x06 0x08
+    for(i in 0..10 step 2) {
+        <i>
+    }
+}
+```
+
+See the [Compile-Time Loops](../huff-language/compile-time-loops.md) documentation for complete details and examples.
+
 ### New test capabilities
 The test module has been refactored to use `anvil` and `forge` features from `foundry` to fork the mainnet. This allows for more advanced testing capabilities.
 

--- a/book/huff-language/compile-time-loops.md
+++ b/book/huff-language/compile-time-loops.md
@@ -1,0 +1,260 @@
+# Compile-Time Loops
+
+Huff Neo supports compile-time `for` loops that expand during compilation, allowing you to generate repetitive code patterns without manual duplication.
+
+## Syntax
+
+```javascript
+for(variable in start..end) {
+    // loop body
+}
+
+for(variable in start..end step N) {
+    // loop body with custom step
+}
+```
+
+## Features
+
+- **Compile-time expansion**: Loops are expanded during compilation and don't exist in the final bytecode
+- **Variable interpolation**: Use `<variable>` to insert the current iteration value as a literal
+- **Constant expressions**: Loop bounds can use constants and arithmetic
+- **Nested loops**: Loops can be nested within each other
+
+## Basic Usage
+
+### Simple Repetition
+
+Generate a sequence of literal values:
+
+```javascript
+#define macro PUSH_SEQUENCE() = takes(0) returns(3) {
+    for(i in 0..3) {
+        <i>
+    }
+    // Expands to: 0x00 0x01 0x02
+}
+```
+
+### With Opcodes
+
+Use loop variables with explicit opcodes:
+
+```javascript
+#define macro PUSH_VALUES() = takes(0) returns(3) {
+    for(i in 1..4) {
+        push1 <i>
+    }
+    // Expands to: push1 0x01 push1 0x02 push1 0x03
+}
+```
+
+### Custom Step
+
+Use a step value other than 1:
+
+```javascript
+#define macro EVEN_NUMBERS() = takes(0) returns(5) {
+    for(i in 0..10 step 2) {
+        <i>
+    }
+    // Expands to: 0x00 0x02 0x04 0x06 0x08
+}
+```
+
+## Variable Interpolation
+
+The `<variable>` syntax inserts the current iteration value as a hex literal (matching Huff's existing `<arg>` syntax for macro arguments):
+
+```javascript
+for(i in 0..3) {
+    <i>  // Becomes: 0x00, then 0x01, then 0x02
+}
+```
+
+**Note**: Loop variables shadow macro arguments. Inside a for loop, `<i>` always refers to the loop variable, even if there's a macro argument with the same name.
+
+### Limitations
+
+- `<variable>` only works as a **literal value**
+- Cannot interpolate into identifiers or label names
+- Cannot use variable in constant names
+
+**Supported**:
+```javascript
+for(i in 0..3) {
+    <i>        // ✓ Literal value
+    push1 <i>  // ✓ Literal after opcode
+}
+```
+
+**Not Supported**:
+```javascript
+for(i in 0..3) {
+    [SLOT_<i>]   // ✗ No interpolation in identifiers
+    label_<i>:   // ✗ No interpolation in labels
+}
+```
+
+## Loop Bounds
+
+Loop bounds must be constant expressions that can be evaluated at compile-time.
+
+### U256 Range Support
+
+Loop ranges support **full u256 values** using hex notation:
+
+```javascript
+#define constant START = 0x00
+#define constant END = 0xFF
+#define constant STEP = 0x10
+
+#define macro USE_CONSTANTS() = takes(0) returns(16) {
+    for(i in START..END step STEP) {
+        <i>
+    }
+}
+```
+
+You can use hex literals directly:
+
+```javascript
+for(i in 0x00..0x100 step 0x20) {
+    <i>
+}
+// Works with any u256 value up to 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+```
+
+### Arithmetic in Bounds
+
+You can use arithmetic expressions:
+
+```javascript
+#define constant SIZE = 5
+
+for(i in 0..SIZE * 2) {
+    <i>
+}
+// Expands iterations from 0 to 9
+```
+
+### Iteration Limit
+
+**Important**: To prevent compile-time explosion and excessive bytecode generation, loops are limited to **10,000 iterations maximum**.
+
+If your loop exceeds this limit, you'll get a compile error:
+
+```javascript
+// This will error - exceeds 10,000 iterations
+for(i in 0..0x10000) {  // 65,536 iterations
+    <i>
+}
+```
+
+This safety limit prevents:
+- Runaway compilation times
+- Out-of-memory errors
+- Accidentally generating massive bytecode
+
+## Nested Loops
+
+Loops can be nested for multi-dimensional patterns:
+
+```javascript
+#define macro NESTED_EXAMPLE() = takes(0) returns(0) {
+    for(i in 0..2) {
+        for(j in 0..2) {
+            // Both i and j are available
+            <i>
+            <j>
+        }
+    }
+    // Expands to: 0x00 0x00 0x00 0x01 0x01 0x00 0x01 0x01
+}
+```
+
+## Common Use Cases
+
+### Initialize Storage Slots
+
+```javascript
+#define macro INIT_STORAGE() = takes(0) returns(0) {
+    for(slot in 0..10) {
+        0x00 <slot> sstore  // Store zero at each slot
+    }
+}
+```
+
+### Generate Function Selector Table
+
+```javascript
+#define macro SELECTOR_TABLE() = takes(0) returns(0) {
+    for(idx in 0..5) {
+        dup1
+        <idx>
+        eq
+        handler jumpi
+    }
+}
+```
+
+### Unroll Loops for Gas Optimization
+
+Instead of runtime loops, unroll them at compile-time:
+
+```javascript
+// Runtime loop (more gas per iteration)
+loop:
+    // ...
+    loop jumpi
+
+// Compile-time loop (no runtime overhead)
+for(i in 0..COUNT) {
+    // ... unrolled code
+}
+```
+
+## Technical Notes
+
+- Loop bounds are inclusive of `start`, exclusive of `end` (like Rust ranges)
+- Default step is 1 if not specified
+- Step must not be zero (compile error)
+- Labels inside loop bodies are automatically renamed to prevent conflicts
+- Maximum iteration count limited by reasonable compile-time bounds
+
+## Examples
+
+### Matrix Operation
+
+```javascript
+#define constant MATRIX_SIZE = 4
+
+#define macro INIT_MATRIX() = takes(0) returns(0) {
+    for(row in 0..MATRIX_SIZE) {
+        for(col in 0..MATRIX_SIZE) {
+            0x00
+            <row>
+            <col>
+            add
+            sstore
+        }
+    }
+}
+```
+
+### Optimized Array Copy
+
+```javascript
+#define constant ARRAY_LENGTH = 32
+
+#define macro COPY_ARRAY() = takes(2) returns(0) {
+    // Takes: source_ptr dest_ptr
+    for(offset in 0..ARRAY_LENGTH step 0x20) {
+        // Load from source
+        dup2 <offset> add mload
+        // Store to dest
+        dup2 <offset> add mstore
+    }
+    pop pop
+}
+```

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 use crate::irgen::builtin_function::{PadDirection, builtin_bytes, builtin_pad, function_signature};
-use alloy_primitives::hex;
+use alloy_primitives::{U256, hex};
 use huff_neo_utils::ast::huff::*;
 use huff_neo_utils::ast::span::AstSpan;
 use huff_neo_utils::bytes_util::str_to_bytes32;
@@ -24,6 +24,9 @@ use std::{cmp::Ordering, collections::HashMap, fs, path::Path, sync::Arc};
 
 mod irgen;
 use crate::irgen::prelude::*;
+
+/// Maximum allowed iterations for compile-time for loops to prevent infinite loops
+const MAX_LOOP_ITERATIONS: usize = 10_000;
 
 /// ### Codegen
 ///
@@ -74,7 +77,9 @@ impl Codegen {
         contract: &Contract,
         alternative_main: Option<String>,
     ) -> Result<(String, Vec<SourceMapEntry>), CodegenError> {
-        let contract = Self::update_table_size(evm_version, contract)?;
+        // Expand for loops before any other processing
+        let contract = Self::expand_for_loops(contract)?;
+        let contract = Self::update_table_size(evm_version, &contract)?;
 
         // If an alternative main is provided, then use it as the compilation target
         let main_macro = alternative_main.unwrap_or_else(|| String::from("MAIN"));
@@ -109,7 +114,9 @@ impl Codegen {
         contract: &Contract,
         alternative_constructor: Option<String>,
     ) -> Result<((String, Vec<SourceMapEntry>), bool), CodegenError> {
-        let contract = Self::update_table_size(evm_version, contract)?;
+        // Expand for loops before any other processing
+        let contract = Self::expand_for_loops(contract)?;
+        let contract = Self::update_table_size(evm_version, &contract)?;
 
         // If an alternative constructor macro is provided, then use it as the compilation target
         let constructor_macro = alternative_constructor.unwrap_or_else(|| String::from("CONSTRUCTOR"));
@@ -150,6 +157,158 @@ impl Codegen {
         let mut contract = contract.clone();
         contract.tables = updated;
         Ok(contract)
+    }
+
+    /// Expand all for loops in the contract at compile-time
+    /// This must be called before bytecode generation
+    pub fn expand_for_loops(contract: &Contract) -> Result<Contract, CodegenError> {
+        let mut contract = contract.clone();
+
+        // Expand loops in all macros
+        let mut expanded_macros = indexmap::IndexMap::new();
+        for (name, macro_def) in contract.macros.iter() {
+            let expanded_statements = Self::expand_statements_for_loops(&macro_def.statements, &contract)?;
+            let mut new_macro = macro_def.clone();
+            new_macro.statements = expanded_statements;
+            expanded_macros.insert(name.clone(), new_macro);
+        }
+        contract.macros = expanded_macros;
+
+        // Expand loops in tables
+        let mut expanded_tables = Vec::new();
+        for table in contract.tables.iter() {
+            let expanded_statements = Self::expand_statements_for_loops(&table.statements, &contract)?;
+            let mut new_table = table.clone();
+            new_table.statements = expanded_statements;
+            expanded_tables.push(new_table);
+        }
+        contract.tables = expanded_tables;
+
+        Ok(contract)
+    }
+
+    /// Recursively expand for loops in a list of statements
+    fn expand_statements_for_loops(statements: &[Statement], contract: &Contract) -> Result<Vec<Statement>, CodegenError> {
+        let mut expanded = Vec::new();
+
+        for statement in statements {
+            match &statement.ty {
+                StatementType::ForLoop { variable, start, end, step, body } => {
+                    // Evaluate loop bounds at compile-time
+                    let start_val = contract.evaluate_constant_expression(start)?;
+                    let end_val = contract.evaluate_constant_expression(end)?;
+                    let step_val = if let Some(step_expr) = step {
+                        contract.evaluate_constant_expression(step_expr)?
+                    } else {
+                        // Default step is 1
+                        str_to_bytes32("1")
+                    };
+
+                    // Convert to U256 for iteration (supports full u256 range)
+                    let start = U256::from_be_bytes(start_val);
+                    let end = U256::from_be_bytes(end_val);
+                    let step = U256::from_be_bytes(step_val);
+
+                    if step.is_zero() {
+                        return Err(CodegenError {
+                            kind: CodegenErrorKind::InvalidLoopStep,
+                            span: statement.span.clone_box(),
+                            token: None,
+                        });
+                    }
+
+                    // Generate iterations with safety limit
+                    let mut current = start;
+                    let mut iteration_count = 0;
+
+                    while current < end {
+                        if iteration_count >= MAX_LOOP_ITERATIONS {
+                            return Err(CodegenError {
+                                kind: CodegenErrorKind::LoopIterationLimitExceeded(MAX_LOOP_ITERATIONS),
+                                span: statement.span.clone_box(),
+                                token: None,
+                            });
+                        }
+
+                        // Clone body and substitute loop variable
+                        let current_bytes = current.to_be_bytes::<32>();
+                        let iteration_body = Self::substitute_loop_variable(body, variable, &current_bytes)?;
+                        // Recursively expand in case of nested loops
+                        let expanded_body = Self::expand_statements_for_loops(&iteration_body, contract)?;
+                        expanded.extend(expanded_body);
+
+                        current = current.saturating_add(step);
+                        iteration_count += 1;
+                    }
+                }
+                StatementType::Label(label) => {
+                    // Recursively expand loops inside labels
+                    let expanded_inner = Self::expand_statements_for_loops(&label.inner, contract)?;
+                    let mut new_label = label.clone();
+                    new_label.inner = expanded_inner;
+                    expanded.push(Statement { ty: StatementType::Label(new_label), span: statement.span.clone() });
+                }
+                _ => {
+                    // Keep other statements as-is
+                    expanded.push(statement.clone());
+                }
+            }
+        }
+
+        Ok(expanded)
+    }
+
+    /// Substitute loop variable in statement body
+    fn substitute_loop_variable(statements: &[Statement], var_name: &str, value: &[u8; 32]) -> Result<Vec<Statement>, CodegenError> {
+        let mut substituted = Vec::new();
+        let var_literal = *value;
+
+        for statement in statements {
+            let new_statement = match &statement.ty {
+                StatementType::Constant(name) => {
+                    // Check if this is a loop variable placeholder
+                    if name == &format!("__LOOP_VAR_{}", var_name) {
+                        // Replace with literal
+                        Statement { ty: StatementType::Literal(var_literal), span: statement.span.clone() }
+                    } else {
+                        statement.clone()
+                    }
+                }
+                StatementType::Label(label) => {
+                    // Recursively substitute in label body
+                    let substituted_inner = Self::substitute_loop_variable(&label.inner, var_name, value)?;
+                    let mut new_label = label.clone();
+                    new_label.inner = substituted_inner;
+                    // Rename label to prevent collisions in different iterations
+                    let iter_value = U256::from_be_bytes(*value);
+                    new_label.name = format!("{}_{}", label.name, iter_value);
+                    Statement { ty: StatementType::Label(new_label), span: statement.span.clone() }
+                }
+                StatementType::LabelCall(label_name) => {
+                    // Update label references to match renamed labels. Wwe rename based on the current iteration.
+                    let iter_value = U256::from_be_bytes(*value);
+                    Statement { ty: StatementType::LabelCall(format!("{}_{}", label_name, iter_value)), span: statement.span.clone() }
+                }
+                StatementType::ForLoop { variable: loop_var, start, end, step, body } => {
+                    // Recursively substitute in nested for loop body
+                    let substituted_body = Self::substitute_loop_variable(body, var_name, value)?;
+                    Statement {
+                        ty: StatementType::ForLoop {
+                            variable: loop_var.clone(),
+                            start: start.clone(),
+                            end: end.clone(),
+                            step: step.clone(),
+                            body: substituted_body,
+                        },
+                        span: statement.span.clone(),
+                    }
+                }
+                _ => statement.clone(),
+            };
+            substituted.push(new_statement);
+        }
+
+        Ok(substituted)
     }
 
     /// Helper function to find a macro or generate a CodegenError

--- a/crates/core/tests/arithmetic_expressions.rs
+++ b/crates/core/tests/arithmetic_expressions.rs
@@ -1,43 +1,7 @@
-use huff_neo_codegen::Codegen;
-use huff_neo_lexer::*;
-use huff_neo_parser::*;
-use huff_neo_utils::error::{CodegenError, CodegenErrorKind};
-use huff_neo_utils::evm_version::EVMVersion;
-use huff_neo_utils::file::full_file_source::FullFileSource;
-use huff_neo_utils::prelude::*;
+mod common;
 
-// Helper Functions
-
-/// Compile a Huff source string and return the main bytecode
-fn compile_to_bytecode(source: &str) -> Result<String, CodegenError> {
-    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source);
-    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
-    let mut parser = Parser::new(tokens, None);
-    let mut contract = parser.parse().unwrap();
-    contract.derive_storage_pointers();
-    Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None)
-}
-
-/// Compile a Huff source string and return the constructor bytecode
-fn compile_to_constructor_bytecode(source: &str) -> Result<(String, bool), CodegenError> {
-    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source);
-    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
-    let mut parser = Parser::new(tokens, None);
-    let mut contract = parser.parse().unwrap();
-    contract.derive_storage_pointers();
-    Codegen::generate_constructor_bytecode(&EVMVersion::default(), &contract, None)
-}
-
-/// Compile a Huff source and assert it produces an error of the expected kind
-fn assert_compile_error(source: &str, expected_kind: fn(&CodegenErrorKind) -> bool) {
-    let result = compile_to_bytecode(source);
-    assert!(result.is_err(), "Expected compilation to fail but it succeeded");
-    if let Err(e) = result {
-        assert!(expected_kind(&e.kind), "Expected error kind mismatch. Got: {:?}", e.kind);
-    }
-}
+use crate::common::{assert_compile_error, compile_to_bytecode, compile_to_constructor_bytecode};
+use huff_neo_utils::error::CodegenErrorKind;
 
 // Basic Arithmetic Operations
 

--- a/crates/core/tests/common.rs
+++ b/crates/core/tests/common.rs
@@ -1,0 +1,40 @@
+#![allow(dead_code)]
+
+use huff_neo_codegen::Codegen;
+use huff_neo_lexer::*;
+use huff_neo_parser::*;
+use huff_neo_utils::error::{CodegenError, CodegenErrorKind};
+use huff_neo_utils::evm_version::EVMVersion;
+use huff_neo_utils::file::full_file_source::FullFileSource;
+use huff_neo_utils::prelude::*;
+
+/// Compile a Huff source string and return the main bytecode
+pub fn compile_to_bytecode(source: &str) -> Result<String, CodegenError> {
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+    Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None)
+}
+
+/// Compile a Huff source string and return the constructor bytecode
+pub fn compile_to_constructor_bytecode(source: &str) -> Result<(String, bool), CodegenError> {
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+    Codegen::generate_constructor_bytecode(&EVMVersion::default(), &contract, None)
+}
+
+/// Compile a Huff source and assert it produces an error of the expected kind
+pub fn assert_compile_error(source: &str, expected_kind: fn(&CodegenErrorKind) -> bool) {
+    let result = compile_to_bytecode(source);
+    assert!(result.is_err(), "Expected compilation to fail but it succeeded");
+    if let Err(e) = result {
+        assert!(expected_kind(&e.kind), "Expected error kind mismatch. Got: {:?}", e.kind);
+    }
+}

--- a/crates/core/tests/for_loops.rs
+++ b/crates/core/tests/for_loops.rs
@@ -1,0 +1,304 @@
+mod common;
+
+use common::compile_to_bytecode;
+
+#[test]
+fn test_for_loop_basic_unrolling() {
+    // Test basic for loop unrolling with literal bounds
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..3) {
+                <i>
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH0, PUSH1 0x01, PUSH1 0x02
+    let expected = "5f60016002";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_with_step() {
+    // Test for loop with step clause
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..6 step 2) {
+                <i>
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH0, PUSH1 0x02, PUSH1 0x04
+    let expected = "5f60026004";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_with_constants() {
+    // Test for loop with constant expressions as bounds
+    let source = r#"
+        #define constant START = 0x01
+        #define constant END = 0x04
+
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in START..END) {
+                <i>
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0x01, PUSH1 0x02, PUSH1 0x03
+    let expected = "600160026003";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_with_arithmetic_bounds() {
+    // Test for loop with arithmetic expressions in bounds
+    let source = r#"
+        #define constant BASE = 0x02
+        #define constant MULTIPLIER = 0x03
+
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in BASE..BASE*MULTIPLIER) {
+                <i>
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0x02, PUSH1 0x03, PUSH1 0x04, PUSH1 0x05
+    // (BASE = 2, BASE * MULTIPLIER = 6, so loop is 2..6)
+    let expected = "6002600360046005";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_nested() {
+    // Test nested for loops
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..2) {
+                for(j in 0..2) {
+                    <i> <j> add
+                }
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode (loop unrolls to):
+    // i=0, j=0: PUSH0 PUSH0 ADD
+    // i=0, j=1: PUSH0 PUSH1 0x01 ADD
+    // i=1, j=0: PUSH1 0x01 PUSH0 ADD
+    // i=1, j=1: PUSH1 0x01 PUSH1 0x01 ADD
+    let expected = "5f5f015f6001016001 5f 01600160010 1".replace(" ", "");
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_with_body_statements() {
+    // Test for loop with multiple statements in the body
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..2) {
+                <i>
+                dup1
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH0 DUP1 PUSH1 0x01 DUP1
+    let expected = "5f80600180";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_sequential() {
+    // Test two sequential for loops
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..2) {
+                <i>
+            }
+            for(j in 0..2) {
+                <j>
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH0 PUSH1 0x01 PUSH0 PUSH1 0x01
+    let expected = "5f60015f6001";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_edge_case_empty_range() {
+    // Test for loop with empty range (start == end)
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 5..5) {
+                <i>
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: empty (no iterations)
+    let expected = "";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_edge_case_single_iteration() {
+    // Test for loop with single iteration
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..1) {
+                <i>
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH0
+    let expected = "5f";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_with_hex_bounds() {
+    // Test for loop with hexadecimal literal bounds
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0x10..0x13) {
+                <i>
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0x10, PUSH1 0x11, PUSH1 0x12
+    let expected = "601060116012";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_with_constant_step() {
+    // Test for loop with constant expression for step
+    let source = r#"
+        #define constant STEP_SIZE = 0x02
+
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..6 step STEP_SIZE) {
+                <i>
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH0, PUSH1 0x02, PUSH1 0x04
+    let expected = "5f60026004";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_empty_body() {
+    // Test for loop with empty body
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..3) {
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: empty (body has no statements)
+    let expected = "";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_with_opcodes_in_body() {
+    // Test for loop with multiple opcodes in the body
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..2) {
+                <i>
+                <i>
+                add
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode:
+    // i=0: PUSH0 PUSH0 ADD
+    // i=1: PUSH1 0x01 PUSH1 0x01 ADD
+    let expected = "5f5f016001600101";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_with_label_in_body() {
+    // Test for loop with label definition in body
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..2) {
+                loop_label:
+                    <i>
+                    loop_label jumpi
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode (each iteration has its own label scope):
+    // i=0: JUMPDEST PUSH0 PUSH2(label_addr) JUMPI
+    // i=1: JUMPDEST PUSH1 0x01 PUSH2(label_addr) JUMPI
+    let expected = "5b5f610000575b600161000657";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_for_loop_deeply_nested() {
+    // Test deeply nested for loops (3 levels)
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..2) {
+                for(j in 0..2) {
+                    for(k in 0..2) {
+                        <i> <j> <k> add add
+                    }
+                }
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: 8 iterations (2^3), each with 3 pushes + 2 adds
+    // Iterations: (i,j,k) = (0,0,0), (0,0,1), (0,1,0), (0,1,1), (1,0,0), (1,0,1), (1,1,0), (1,1,1)
+    let expected = "5f5f5f01015f5f600101015f60015f01015f60016001010160015f5f010160015f60010101600160015f01016001600160010101";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}

--- a/crates/lexer/src/context_stack.rs
+++ b/crates/lexer/src/context_stack.rs
@@ -3,14 +3,20 @@ use huff_neo_utils::lexer_context::Context;
 
 // The context stack is used to keep track of the current context.
 //
+// Complete context hierarchy showing all possible parent-child relationships:
+//
 // Context::Global
 // ├─ Context::Constant
 // ├─ Context::Abi
 // │  └─ Context::AbiArgs
 // ├─ Context::MacroDefinition
-// │  └─ Context::MacroArgs
-// ├─ Context::MacroBody
-// │  └─ Context::BuiltinFunction
+// │  └─ Context::MacroBody
+// │     ├─ Context::BuiltinFunction
+// │     ├─ Context::MacroArgs
+// │     └─ Context::ForLoopBody
+// │        ├─ Context::BuiltinFunction
+// │        ├─ Context::MacroArgs
+// │        └─ Context::ForLoopBody (nested)
 // └─ Context::CodeTableBody
 
 /// The context stack is used to keep track of the current context

--- a/crates/lexer/tests/for_loops.rs
+++ b/crates/lexer/tests/for_loops.rs
@@ -1,0 +1,347 @@
+use huff_neo_lexer::*;
+use huff_neo_utils::prelude::*;
+
+#[test]
+fn parses_for_loop_basic() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..5) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+
+    // Lex 'for' keyword
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let for_span = Span::new(45..48, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::For, for_span));
+
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // i (identifier)
+    let _ = lexer.next(); // whitespace
+
+    // Lex 'in' keyword
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let in_span = Span::new(51..53, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::In, in_span));
+
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // 0
+
+    // Lex '..' (DoubleDot)
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let doubledot_span = Span::new(55..57, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::DoubleDot, doubledot_span));
+
+    let _ = lexer.next(); // 5
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // eof
+
+    // We covered the whole source
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_for_loop_with_step() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..10 step 2) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // for
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // i
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // in
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // ..
+    let _ = lexer.next(); // 10
+    let _ = lexer.next(); // whitespace
+
+    // Lex 'step' keyword
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let step_span = Span::new(60..64, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::Step, step_span));
+
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // 2
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // eof
+
+    // We covered the whole source
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_for_loop_nested() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..2) { for(j in 0..2) { } } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+
+    // First 'for' keyword
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    assert_eq!(unwrapped.kind, TokenKind::For);
+
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // i
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // in
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // ..
+    let _ = lexer.next(); // 2
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+
+    // Second 'for' keyword
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    assert_eq!(unwrapped.kind, TokenKind::For);
+
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // j
+    let _ = lexer.next(); // whitespace
+
+    // Second 'in' keyword
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    assert_eq!(unwrapped.kind, TokenKind::In);
+
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // ..
+    let _ = lexer.next(); // 2
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // eof
+
+    // We covered the whole source
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_for_loop_with_variable_interpolation() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..3) { <i> } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // for
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // i
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // in
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // ..
+    let _ = lexer.next(); // 3
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+
+    // Lex '<' (LeftAngle)
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    assert_eq!(unwrapped.kind, TokenKind::LeftAngle);
+
+    // Lex 'i' (identifier)
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    assert_eq!(unwrapped.kind, TokenKind::Ident("i".to_string()));
+
+    // Lex '>' (RightAngle)
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    assert_eq!(unwrapped.kind, TokenKind::RightAngle);
+
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // eof
+
+    // We covered the whole source
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_for_loop_with_hex_bounds() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0x00..0xFF) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Just verify it lexes without error
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_for_loop_with_constants() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in START..END) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Just verify it lexes without error
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_for_loop_tight_spacing() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..10) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Just verify it lexes without error
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_for_loop_loose_spacing() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for( i in 0 .. 10 ) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Just verify it lexes without error
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_for_loop_empty_body() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..5) {} }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Just verify it lexes without error
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_for_loop_with_newlines() {
+    let source = r#"#define macro TEST() = takes(0) returns(0) {
+    for(i in 0..3) {
+        <i>
+    }
+}"#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Just verify it lexes without error
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}

--- a/crates/parser/tests/for_loops.rs
+++ b/crates/parser/tests/for_loops.rs
@@ -1,0 +1,381 @@
+use huff_neo_lexer::*;
+use huff_neo_parser::*;
+use huff_neo_utils::{file::full_file_source::FullFileSource, prelude::*};
+
+#[test]
+fn test_for_loop_basic_literals() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..5) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    let expected_statement = Statement {
+        ty: StatementType::ForLoop {
+            variable: "i".to_string(),
+            start: Expression::Literal { value: str_to_bytes32("00"), span: AstSpan(vec![Span { start: 54, end: 55, file: None }]) },
+            end: Expression::Literal { value: str_to_bytes32("05"), span: AstSpan(vec![Span { start: 57, end: 58, file: None }]) },
+            step: None,
+            body: vec![],
+        },
+        span: AstSpan(vec![
+            Span { start: 45, end: 48, file: None }, // "for"
+            Span { start: 48, end: 49, file: None }, // "("
+            Span { start: 49, end: 50, file: None }, // "i"
+            Span { start: 51, end: 53, file: None }, // "in"
+            Span { start: 54, end: 55, file: None }, // "0"
+            Span { start: 55, end: 57, file: None }, // ".."
+            Span { start: 57, end: 58, file: None }, // "5"
+            Span { start: 58, end: 59, file: None }, // ")"
+            Span { start: 60, end: 61, file: None }, // "{"
+            Span { start: 62, end: 63, file: None }, // "}"
+        ]),
+    };
+
+    assert_eq!(macro_definition.statements[0], expected_statement);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_for_loop_with_step() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..10 step 2) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    let expected_statement = Statement {
+        ty: StatementType::ForLoop {
+            variable: "i".to_string(),
+            start: Expression::Literal { value: str_to_bytes32("00"), span: AstSpan(vec![Span { start: 54, end: 55, file: None }]) },
+            end: Expression::Literal { value: str_to_bytes32("10"), span: AstSpan(vec![Span { start: 57, end: 59, file: None }]) },
+            step: Some(Expression::Literal { value: str_to_bytes32("02"), span: AstSpan(vec![Span { start: 65, end: 66, file: None }]) }),
+            body: vec![],
+        },
+        span: AstSpan(vec![
+            Span { start: 45, end: 48, file: None }, // "for"
+            Span { start: 48, end: 49, file: None }, // "("
+            Span { start: 49, end: 50, file: None }, // "i"
+            Span { start: 51, end: 53, file: None }, // "in"
+            Span { start: 54, end: 55, file: None }, // "0"
+            Span { start: 55, end: 57, file: None }, // ".."
+            Span { start: 57, end: 59, file: None }, // "10"
+            Span { start: 60, end: 64, file: None }, // "step"
+            Span { start: 65, end: 66, file: None }, // "2"
+            Span { start: 66, end: 67, file: None }, // ")"
+            Span { start: 68, end: 69, file: None }, // "{"
+            Span { start: 70, end: 71, file: None }, // "}"
+        ]),
+    };
+
+    assert_eq!(macro_definition.statements[0], expected_statement);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_for_loop_with_constants() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in START..END) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    let expected_statement = Statement {
+        ty: StatementType::ForLoop {
+            variable: "i".to_string(),
+            start: Expression::Constant { name: "START".to_string(), span: AstSpan(vec![Span { start: 54, end: 59, file: None }]) },
+            end: Expression::Constant { name: "END".to_string(), span: AstSpan(vec![Span { start: 61, end: 64, file: None }]) },
+            step: None,
+            body: vec![],
+        },
+        span: AstSpan(vec![
+            Span { start: 45, end: 48, file: None }, // "for"
+            Span { start: 48, end: 49, file: None }, // "("
+            Span { start: 49, end: 50, file: None }, // "i"
+            Span { start: 51, end: 53, file: None }, // "in"
+            Span { start: 54, end: 59, file: None }, // "START"
+            Span { start: 59, end: 61, file: None }, // ".."
+            Span { start: 61, end: 64, file: None }, // "END"
+            Span { start: 64, end: 65, file: None }, // ")"
+            Span { start: 66, end: 67, file: None }, // "{"
+            Span { start: 68, end: 69, file: None }, // "}"
+        ]),
+    };
+
+    assert_eq!(macro_definition.statements[0], expected_statement);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_for_loop_with_arithmetic_bounds() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..SIZE * 2) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    let expected_statement = Statement {
+        ty: StatementType::ForLoop {
+            variable: "i".to_string(),
+            start: Expression::Literal { value: str_to_bytes32("00"), span: AstSpan(vec![Span { start: 54, end: 55, file: None }]) },
+            end: Expression::Binary {
+                left: Box::new(Expression::Constant {
+                    name: "SIZE".to_string(),
+                    span: AstSpan(vec![Span { start: 57, end: 61, file: None }]),
+                }),
+                op: BinaryOp::Mul,
+                right: Box::new(Expression::Literal {
+                    value: str_to_bytes32("02"),
+                    span: AstSpan(vec![Span { start: 64, end: 65, file: None }]),
+                }),
+                span: AstSpan(vec![
+                    Span { start: 57, end: 61, file: None }, // "SIZE"
+                    Span { start: 62, end: 63, file: None }, // "*"
+                    Span { start: 64, end: 65, file: None }, // "2"
+                ]),
+            },
+            step: None,
+            body: vec![],
+        },
+        span: AstSpan(vec![
+            Span { start: 45, end: 48, file: None }, // "for"
+            Span { start: 48, end: 49, file: None }, // "("
+            Span { start: 49, end: 50, file: None }, // "i"
+            Span { start: 51, end: 53, file: None }, // "in"
+            Span { start: 54, end: 55, file: None }, // "0"
+            Span { start: 55, end: 57, file: None }, // ".."
+            Span { start: 57, end: 61, file: None }, // "SIZE"
+            Span { start: 62, end: 63, file: None }, // "*"
+            Span { start: 64, end: 65, file: None }, // "2"
+            Span { start: 65, end: 66, file: None }, // ")"
+            Span { start: 67, end: 68, file: None }, // "{"
+            Span { start: 69, end: 70, file: None }, // "}"
+        ]),
+    };
+
+    assert_eq!(macro_definition.statements[0], expected_statement);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_for_loop_with_variable_interpolation() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..3) { <i> } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Just check the structure, not exact spans since body parsing may differ
+    let actual_stmt = &macro_definition.statements[0];
+    match &actual_stmt.ty {
+        StatementType::ForLoop { variable, start, end, step, body } => {
+            assert_eq!(variable, "i");
+            assert!(matches!(start, Expression::Literal { .. }));
+            assert!(matches!(end, Expression::Literal { .. }));
+            assert!(step.is_none());
+            assert_eq!(body.len(), 1);
+            assert!(matches!(body[0].ty, StatementType::Constant(ref s) if s == "__LOOP_VAR_i"));
+        }
+        _ => panic!("Expected ForLoop statement"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_for_loop_nested() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..2) { for(j in 0..2) { } } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Just check structure for nested loops due to complexity
+    let outer_stmt = &macro_definition.statements[0];
+    match &outer_stmt.ty {
+        StatementType::ForLoop { variable, body, .. } => {
+            assert_eq!(variable, "i");
+            assert_eq!(body.len(), 1);
+            match &body[0].ty {
+                StatementType::ForLoop { variable: inner_var, .. } => {
+                    assert_eq!(inner_var, "j");
+                }
+                _ => panic!("Expected nested ForLoop"),
+            }
+        }
+        _ => panic!("Expected outer ForLoop"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_for_loop_sequential() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..2) { } for(j in 0..3) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 2);
+
+    // Check first loop
+    match &macro_definition.statements[0].ty {
+        StatementType::ForLoop { variable, .. } => {
+            assert_eq!(variable, "i");
+        }
+        _ => panic!("Expected first ForLoop"),
+    }
+
+    // Check second loop
+    match &macro_definition.statements[1].ty {
+        StatementType::ForLoop { variable, .. } => {
+            assert_eq!(variable, "j");
+        }
+        _ => panic!("Expected second ForLoop"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_for_loop_with_hex_bounds() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0x00..0xFF) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    let expected_statement = Statement {
+        ty: StatementType::ForLoop {
+            variable: "i".to_string(),
+            start: Expression::Literal { value: str_to_bytes32("00"), span: AstSpan(vec![Span { start: 54, end: 58, file: None }]) },
+            end: Expression::Literal { value: str_to_bytes32("ff"), span: AstSpan(vec![Span { start: 60, end: 64, file: None }]) },
+            step: None,
+            body: vec![],
+        },
+        span: AstSpan(vec![
+            Span { start: 45, end: 48, file: None }, // "for"
+            Span { start: 48, end: 49, file: None }, // "("
+            Span { start: 49, end: 50, file: None }, // "i"
+            Span { start: 51, end: 53, file: None }, // "in"
+            Span { start: 54, end: 58, file: None }, // "0x00"
+            Span { start: 58, end: 60, file: None }, // ".."
+            Span { start: 60, end: 64, file: None }, // "0xFF"
+            Span { start: 64, end: 65, file: None }, // ")"
+            Span { start: 66, end: 67, file: None }, // "{"
+            Span { start: 68, end: 69, file: None }, // "}"
+        ]),
+    };
+
+    assert_eq!(macro_definition.statements[0], expected_statement);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_for_loop_with_body_statements() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..3) { <i> 0x00 mstore } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Check structure rather than exact spans due to body complexity
+    let stmt = &macro_definition.statements[0];
+    match &stmt.ty {
+        StatementType::ForLoop { variable, body, .. } => {
+            assert_eq!(variable, "i");
+            assert_eq!(body.len(), 3);
+            assert!(matches!(body[0].ty, StatementType::Constant(ref s) if s == "__LOOP_VAR_i"));
+            assert!(matches!(body[1].ty, StatementType::Literal(_)));
+            assert!(matches!(body[2].ty, StatementType::Opcode(Opcode::Mstore)));
+        }
+        _ => panic!("Expected ForLoop"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_for_loop_with_constant_step() {
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..10 step STEP) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    let expected_statement = Statement {
+        ty: StatementType::ForLoop {
+            variable: "i".to_string(),
+            start: Expression::Literal { value: str_to_bytes32("00"), span: AstSpan(vec![Span { start: 54, end: 55, file: None }]) },
+            end: Expression::Literal { value: str_to_bytes32("10"), span: AstSpan(vec![Span { start: 57, end: 59, file: None }]) },
+            step: Some(Expression::Constant { name: "STEP".to_string(), span: AstSpan(vec![Span { start: 65, end: 69, file: None }]) }),
+            body: vec![],
+        },
+        span: AstSpan(vec![
+            Span { start: 45, end: 48, file: None }, // "for"
+            Span { start: 48, end: 49, file: None }, // "("
+            Span { start: 49, end: 50, file: None }, // "i"
+            Span { start: 51, end: 53, file: None }, // "in"
+            Span { start: 54, end: 55, file: None }, // "0"
+            Span { start: 55, end: 57, file: None }, // ".."
+            Span { start: 57, end: 59, file: None }, // "10"
+            Span { start: 60, end: 64, file: None }, // "step"
+            Span { start: 65, end: 69, file: None }, // "STEP"
+            Span { start: 69, end: 70, file: None }, // ")"
+            Span { start: 71, end: 72, file: None }, // "{"
+            Span { start: 73, end: 74, file: None }, // "}"
+        ]),
+    };
+
+    assert_eq!(macro_definition.statements[0], expected_statement);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -238,6 +238,10 @@ pub enum CodegenErrorKind {
     DivisionByZero,
     /// Invalid opcode for EVM version (opcode, required_version, current_version)
     InvalidOpcodeForEVMVersion(String, String, String),
+    /// Invalid loop step value (step cannot be zero)
+    InvalidLoopStep,
+    /// Loop iteration limit exceeded (contains max limit)
+    LoopIterationLimitExceeded(usize),
 }
 
 impl Spanned for CodegenError {
@@ -350,6 +354,12 @@ impl<W: Write> Report<W> for CodegenError {
                     "Opcode '{}' requires EVM version '{}' or later (current version: '{}')",
                     opcode, required_version, current_version
                 )
+            }
+            CodegenErrorKind::InvalidLoopStep => {
+                write!(f.out, "Invalid loop step: step value cannot be zero")
+            }
+            CodegenErrorKind::LoopIterationLimitExceeded(max) => {
+                write!(f.out, "Loop iteration limit exceeded: maximum {} iterations allowed at compile-time", max)
             }
         }
     }
@@ -678,6 +688,17 @@ impl fmt::Display for CompilerError {
                         opcode,
                         required_version,
                         current_version,
+                        ce.span.error(None)
+                    )
+                }
+                CodegenErrorKind::InvalidLoopStep => {
+                    write!(f, "\nError: Invalid loop step: step value cannot be zero\n{}\n", ce.span.error(None))
+                }
+                CodegenErrorKind::LoopIterationLimitExceeded(max) => {
+                    write!(
+                        f,
+                        "\nError: Loop iteration limit exceeded\nMaximum {} iterations allowed at compile-time\n{}\n",
+                        max,
                         ce.span.error(None)
                     )
                 }

--- a/crates/utils/src/lexer_context.rs
+++ b/crates/utils/src/lexer_context.rs
@@ -21,4 +21,6 @@ pub enum Context {
     CodeTableBody,
     /// Built-in function context
     BuiltinFunction,
+    /// For loop body context
+    ForLoopBody,
 }

--- a/crates/utils/src/token.rs
+++ b/crates/utils/src/token.rs
@@ -136,6 +136,14 @@ pub enum TokenKind {
     Memory,
     /// Storage Data Location
     Storage,
+    /// "for" keyword
+    For,
+    /// "in" keyword
+    In,
+    /// "step" keyword
+    Step,
+    /// ".." range operator
+    DoubleDot,
 }
 
 impl TokenKind {
@@ -224,6 +232,10 @@ impl fmt::Display for TokenKind {
             TokenKind::Calldata => return write!(f, "calldata"),
             TokenKind::Memory => return write!(f, "memory"),
             TokenKind::Storage => return write!(f, "storage"),
+            TokenKind::For => "for",
+            TokenKind::In => "in",
+            TokenKind::Step => "step",
+            TokenKind::DoubleDot => "..",
         };
 
         write!(f, "{x}")


### PR DESCRIPTION
- Add compile-time for-loops that expand during compilation.
  - Syntax: `for(variable in start..end) { body }` or `for(variable in start..end step N) { body }`
  - Support for a loop variable with `<variable>`.
    - Example: `for(i in 0..5) { <i> }` expands to `0x00 0x01 0x02 0x03 0x04`