### PR TITLE
feat: introduce `__NOOP` builtin constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   - Syntax: `for(variable in start..end) { body }` or `for(variable in start..end step N) { body }`
   - Support for a loop variable with `<variable>`.
     - Example: `for(i in 0..5) { <i> }` expands to `0x00 0x01 0x02 0x03 0x04`
+- Add `__NOOP` builtin constant that generates no bytecode.
+  - Can be used e.g. for optional macro arguments `MACRO(__NOOP)`.
 
 ## [1.3.10] - 2025-11-01
 - Fix macro argument scoping to prevent arguments from leaking into nested macros that don't receive them (fixes #108).

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Huff Language](huff-language/overview.md)
   - [Macros and Functions](huff-language/macros-and-functions.md)
   - [Builtin Functions](huff-language/builtin-functions.md)
+  - [Builtin Constants](huff-language/builtin-constants.md)
   - [Functions and events](huff-language/functions-and-events.md)
   - [Constants](huff-language/constants.md)
   - [Compile-Time Loops](huff-language/compile-time-loops.md)

--- a/book/huff-language/builtin-constants.md
+++ b/book/huff-language/builtin-constants.md
@@ -1,0 +1,60 @@
+# Builtin Constants
+
+Built-in constants are compiler-provided constants with special behavior during compilation. Unlike user-defined constants which resolve to literal values, built-in constants may generate specialized bytecode or no bytecode.
+
+## `__NOOP`
+
+At compile time, `__NOOP` generates no bytecode. When the compiler encounters `__NOOP`, it skips code generation for that position.
+
+### Behavior
+
+- `__NOOP` can appear in macro bodies, as macro arguments, in for loop bodies, and inside label definitions
+- When referenced through constants (`[CONST]`), it generates no bytecode
+- `__NOOP` is a reserved name and cannot be used for user-defined constants
+
+### Example: Basic Usage
+
+```javascript
+#define macro EXAMPLE() = takes(0) returns(0) {
+    __NOOP       // Generates: (nothing)
+    0x01         // Generates: PUSH1 0x01 = 6001
+    __NOOP       // Generates: (nothing)
+    dup1         // Generates: DUP1 = 80
+    __NOOP       // Generates: (nothing)
+}
+// Total bytecode: 600180
+```
+
+### Example: As a Named Constant
+
+```javascript
+#define constant NO_OP = __NOOP
+
+#define macro MAIN() = takes(0) returns(0) {
+    [NO_OP]  // Generates no bytecode
+    0x42     // Generates: PUSH1 0x42
+}
+```
+
+### Example: Conditional Code via Macro Arguments
+
+```javascript
+#define macro OPTIONAL_LOG(value, should_log) = takes(0) returns(0) {
+    <should_log>  // Expands to opcodes or __NOOP
+    <value>
+}
+
+#define macro MAIN() = takes(0) returns(0) {
+    // With logging
+    OPTIONAL_LOG(0xff, log0)  // Generates: LOG0 PUSH1 0xff
+
+    // Without logging
+    OPTIONAL_LOG(0xff, __NOOP)  // Generates: PUSH1 0xff
+}
+```
+
+## See Also
+
+- [Builtin Functions](./builtin-functions.md) - Compile-time functions like `__FUNC_SIG()` and `__TABLESIZE()`
+- [Constants](./constants.md) - User-defined constants and `FREE_STORAGE_POINTER()`
+- [Macros and Functions](./macros-and-functions.md) - How to use `__NOOP` with macro arguments

--- a/book/huff-language/builtin-functions.md
+++ b/book/huff-language/builtin-functions.md
@@ -97,3 +97,8 @@ Some builtin functions can be combined with other functions. Possible combinatio
         TEST2()
 }
 ```
+
+## See Also
+
+- **[Constants](./constants.md#free_storage_pointer)** - Documentation for `FREE_STORAGE_POINTER()`, a special compile-time function that allocates unique storage slots
+- **[Builtin Constants](./builtin-constants.md)** - Documentation for built-in constants like `__NOOP`

--- a/crates/codegen/src/irgen/arg_calls.rs
+++ b/crates/codegen/src/irgen/arg_calls.rs
@@ -164,6 +164,10 @@ pub fn bubble_arg_call(
                         *offset += b.0.len() / 2;
                         bytes.push((starting_offset, b));
                     }
+                    MacroArg::Noop => {
+                        tracing::info!(target: "codegen", "GOT __NOOP ARG FROM MACRO INVOCATION - GENERATING NO BYTECODE");
+                        // Generate no bytecode - __NOOP is a no-op
+                    }
                     MacroArg::ArgCall(ArgCall { macro_name: ac_parent_macro_name, name: ac, span: arg_span }) => {
                         tracing::info!(target: "codegen", "GOT ARG CALL \"{}\" ARG FROM MACRO INVOCATION", ac);
                         tracing::debug!(target: "codegen", "~~~ BUBBLING UP ARG CALL");
@@ -248,6 +252,10 @@ pub fn bubble_arg_call(
                                     tracing::info!(target: "codegen", "EVALUATING CONSTANT EXPRESSION FOR \"{}\"", constant.name);
                                     let evaluated = contract.evaluate_constant_expression(expr)?;
                                     literal_gen(evm_version, &evaluated)
+                                }
+                                ConstVal::Noop => {
+                                    tracing::info!(target: "codegen", "CONSTANT \"{}\" IS __NOOP - GENERATING NO BYTECODE IN ARGCALL", constant.name);
+                                    String::new() // Generate no bytecode
                                 }
                                 ConstVal::FreeStoragePointer(fsp) => {
                                     // If this is reached in codegen stage,

--- a/crates/codegen/src/irgen/constants.rs
+++ b/crates/codegen/src/irgen/constants.rs
@@ -24,6 +24,10 @@ pub fn constant_gen(evm_version: &EVMVersion, name: &str, contract: &Contract, i
             let evaluated = contract.evaluate_constant_expression(expr)?;
             literal_gen(evm_version, &evaluated)
         }
+        ConstVal::Noop => {
+            tracing::info!(target: "codegen", "CONSTANT \"{}\" IS __NOOP - GENERATING NO BYTECODE", constant.name);
+            String::new() // Generate no bytecode
+        }
         ConstVal::FreeStoragePointer(fsp) => {
             // If this is reached in codegen stage, the `derive_storage_pointers`
             // method was not called on the AST.

--- a/crates/core/tests/noop_builtin.rs
+++ b/crates/core/tests/noop_builtin.rs
@@ -1,0 +1,267 @@
+use huff_neo_codegen::*;
+use huff_neo_lexer::*;
+use huff_neo_parser::*;
+use huff_neo_utils::file::full_file_source::FullFileSource;
+use huff_neo_utils::prelude::*;
+
+#[test]
+fn test_noop_in_macro_generates_no_bytecode() {
+    let source: &str = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            __NOOP
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let evm_version = &EVMVersion::default();
+    let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None).unwrap();
+
+    // __NOOP should generate empty bytecode
+    assert_eq!(main_bytecode, String::from(""));
+}
+
+#[test]
+fn test_noop_mixed_with_opcodes() {
+    let source: &str = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            __NOOP
+            0x01
+            __NOOP
+            dup1
+            __NOOP
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let evm_version = &EVMVersion::default();
+    let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None).unwrap();
+
+    // Should only have PUSH1 0x01 and DUP1
+    assert_eq!(main_bytecode, String::from("600180"));
+}
+
+#[test]
+fn test_noop_as_constant() {
+    let source: &str = r#"
+        #define constant MY_NOOP = __NOOP
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [MY_NOOP]
+            0x42
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let evm_version = &EVMVersion::default();
+    let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None).unwrap();
+
+    // [MY_NOOP] should generate no bytecode, only PUSH1 0x42
+    assert_eq!(main_bytecode, String::from("6042"));
+}
+
+#[test]
+fn test_noop_directly_in_main() {
+    // Test that __NOOP can be used directly in MAIN, not as a macro argument
+    // Using __NOOP as a macro argument that gets expanded with <arg> doesn't make sense
+    // since it would try to reference a non-existent label
+    let source: &str = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            __NOOP
+            0x42
+            __NOOP
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let evm_version = &EVMVersion::default();
+    let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None).unwrap();
+
+    // Should only have PUSH1 0x42, no bytecode for __NOOP
+    assert_eq!(main_bytecode, String::from("6042"));
+}
+
+#[test]
+fn test_noop_in_constructor() {
+    let source: &str = r#"
+        #define macro CONSTRUCTOR() = takes(0) returns(0) {
+            __NOOP
+            0x01 0x00 mstore
+            __NOOP
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {}
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let evm_version = &EVMVersion::default();
+    let (constructor_bytecode, _) = Codegen::generate_constructor_bytecode(evm_version, &contract, None).unwrap();
+
+    // Should have: PUSH1 0x01, PUSH0, MSTORE
+    assert_eq!(constructor_bytecode, String::from("60015f52"));
+}
+
+#[test]
+fn test_noop_in_for_loop() {
+    let source: &str = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            for(i in 0..2) {
+                __NOOP
+                0x01
+                __NOOP
+            }
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let evm_version = &EVMVersion::default();
+    let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None).unwrap();
+
+    // Loop unrolls to: 0x01 0x01 (two iterations, only the PUSH1 0x01 each time)
+    assert_eq!(main_bytecode, String::from("60016001"));
+}
+
+#[test]
+fn test_noop_in_label() {
+    let source: &str = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            my_label:
+                __NOOP
+                0x42
+                __NOOP
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let evm_version = &EVMVersion::default();
+    let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None).unwrap();
+
+    // Should have JUMPDEST (5b) + PUSH1 0x42
+    assert_eq!(main_bytecode, String::from("5b6042"));
+}
+
+#[test]
+fn test_rejects_noop_as_constant_name() {
+    let source: &str = r#"
+        #define constant __NOOP = 0x00
+
+        #define macro MAIN() = takes(0) returns(0) {}
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let result = parser.parse();
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err.kind, ParserErrorKind::InvalidConstantName));
+}
+
+#[test]
+fn test_noop_multiple_in_sequence() {
+    let source: &str = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            __NOOP
+            __NOOP
+            __NOOP
+            0x01
+            __NOOP
+            __NOOP
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let evm_version = &EVMVersion::default();
+    let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None).unwrap();
+
+    // Only PUSH1 0x01 should remain
+    assert_eq!(main_bytecode, String::from("6001"));
+}
+
+#[test]
+fn test_noop_standalone_usage() {
+    // Test that __NOOP works in various standalone contexts
+    let source: &str = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            __NOOP        // Before opcode
+            dup1
+            __NOOP        // After opcode
+            pop
+            __NOOP        // Multiple in sequence
+            __NOOP
+            0x01
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let evm_version = &EVMVersion::default();
+    let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None).unwrap();
+
+    // Should have: DUP1, POP, PUSH1 0x01 (all __NOOP instances generate nothing)
+    // DUP1 = 80, POP = 50, PUSH1 0x01 = 6001
+    assert_eq!(main_bytecode, String::from("80506001"));
+}

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -252,6 +252,14 @@ impl<'a> Lexer<'a> {
                         found_kind = Some(TokenKind::FreeStoragePointer);
                     }
 
+                    // Check for __NOOP builtin constant
+                    if word == "__NOOP"
+                        && matches!(self.context_stack.top(), &Context::MacroBody | &Context::ForLoopBody | &Context::Constant)
+                    {
+                        debug!(target: "lexer", "FOUND __NOOP");
+                        found_kind = Some(TokenKind::Noop);
+                    }
+
                     if let Some(':') = self.peek() {
                         debug!(target: "lexer", "FOUND LABEL '{:?}'", word);
                         found_kind = Some(TokenKind::Label(word.clone()));

--- a/crates/lexer/tests/noop.rs
+++ b/crates/lexer/tests/noop.rs
@@ -1,0 +1,207 @@
+use huff_neo_lexer::*;
+use huff_neo_utils::file::full_file_source::FullFileSource;
+use huff_neo_utils::prelude::*;
+
+#[test]
+fn noop_in_macro_body() {
+    let source = r#"#define macro TEST() = takes(0) returns(0) {
+            __NOOP
+        }"#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+
+    // The __NOOP builtin should be parsed as TokenKind::Noop here
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let noop_span = Span::new(57..63, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::Noop, noop_span));
+
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // eof
+
+    // We covered the whole source
+    assert!(lexer.eof);
+}
+
+#[test]
+fn noop_with_other_opcodes() {
+    let source = "#define macro TEST() = takes(0) returns(0) { 0x01 __NOOP dup1 __NOOP }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // 0x01
+    let _ = lexer.next(); // whitespace
+
+    // First __NOOP
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let noop_span = Span::new(50..56, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::Noop, noop_span));
+
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // dup1
+    let _ = lexer.next(); // whitespace
+
+    // Second __NOOP
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let noop_span2 = Span::new(62..68, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::Noop, noop_span2));
+
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // eof
+
+    // We covered the whole source
+    assert!(lexer.eof);
+}
+
+#[test]
+fn noop_in_for_loop() {
+    let source = r#"#define macro TEST() = takes(0) returns(0) { for(i in 0..5) {
+                __NOOP
+            } }"#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // for
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // i
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // in
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // ..
+    let _ = lexer.next(); // 5
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+
+    // The __NOOP builtin should work in ForLoopBody context
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let noop_span = Span::new(78..84, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::Noop, noop_span));
+
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // eof
+
+    // We covered the whole source
+    assert!(lexer.eof);
+}
+
+#[test]
+fn noop_in_constant_context() {
+    let source = "#define constant MY_NOOP = __NOOP";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // constant
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // MY_NOOP
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+
+    // The __NOOP builtin should be parsed as TokenKind::Noop in constant context
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let noop_span = Span::new(27..33, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::Noop, noop_span));
+
+    let _ = lexer.next(); // eof
+
+    // We covered the whole source
+    assert!(lexer.eof);
+}
+
+#[test]
+#[should_panic]
+fn fails_to_parse_noop_outside_valid_context() {
+    // __NOOP should only be lexed in MacroBody, ForLoopBody, or Constant contexts
+    let source = "__NOOP";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    // This should NOT be TokenKind::Noop in top-level context
+    assert_eq!(unwrapped, Token::new(TokenKind::Noop, Span::new(0..6, None)));
+
+    let _ = lexer.next(); // eof
+    assert!(lexer.eof);
+}

--- a/crates/parser/tests/noop.rs
+++ b/crates/parser/tests/noop.rs
@@ -1,0 +1,147 @@
+use huff_neo_lexer::*;
+use huff_neo_parser::*;
+use huff_neo_utils::file::full_file_source::FullFileSource;
+use huff_neo_utils::{opcodes::Opcode, prelude::*};
+
+#[test]
+fn test_parses_noop_constant() {
+    let source = "#define constant MY_NOOP = __NOOP";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+    let noop_constant = contract.constants.lock().unwrap()[0].clone();
+    assert_eq!(noop_constant.name, "MY_NOOP");
+    assert_eq!(noop_constant.value, ConstVal::Noop);
+    assert_eq!(noop_constant.span.0.len(), 5); // Has 5 spans
+}
+
+#[test]
+fn test_rejects_noop_as_constant_name() {
+    let source = "#define constant __NOOP = 0x00";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let result = parser.parse();
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    // Should get a helpful error that __NOOP is reserved
+    assert!(matches!(err.kind, ParserErrorKind::InvalidConstantName));
+    assert!(err.hint.unwrap().contains("reserved"));
+}
+
+#[test]
+fn test_parses_noop_in_macro_body() {
+    let source = r#"#define macro TEST() = takes(0) returns(0) {
+            __NOOP
+            0x01
+            __NOOP
+        }"#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+    let test_macro = contract.macros.iter().find(|m| m.1.name == "TEST").unwrap().1;
+
+    // __NOOP should not create any statements, so we should only have the 0x01 literal
+    assert_eq!(test_macro.statements.len(), 1);
+    assert!(matches!(test_macro.statements[0].ty, StatementType::Literal(_)));
+    assert_eq!(test_macro.statements[0].ty, StatementType::Literal(str_to_bytes32("01")));
+}
+
+#[test]
+fn test_parses_noop_in_for_loop() {
+    let source = r#"#define macro TEST() = takes(0) returns(0) {
+            for(i in 0..3) {
+                __NOOP
+                dup1
+            }
+        }"#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+    let test_macro = contract.macros.iter().find(|m| m.1.name == "TEST").unwrap().1;
+
+    // Should have one for loop statement
+    assert_eq!(test_macro.statements.len(), 1);
+
+    if let StatementType::ForLoop { body, variable, start, end, step } = &test_macro.statements[0].ty {
+        // Inside the for loop, __NOOP should be skipped, only dup1 remains
+        assert_eq!(body.len(), 1);
+        assert_eq!(variable, "i");
+        assert!(step.is_none());
+
+        // Check the dup1 opcode
+        assert_eq!(body[0].ty, StatementType::Opcode(Opcode::Dup1));
+
+        // Check start and end are literals
+        assert!(matches!(start, Expression::Literal { .. }));
+        assert!(matches!(end, Expression::Literal { .. }));
+    } else {
+        panic!("Expected ForLoop statement");
+    }
+}
+
+#[test]
+fn test_parses_noop_in_label() {
+    let source = r#"#define macro TEST() = takes(0) returns(0) {
+            my_label:
+                __NOOP
+                0x01
+                __NOOP
+        }"#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+    let test_macro = contract.macros.iter().find(|m| m.1.name == "TEST").unwrap().1;
+
+    // Should have one label statement
+    assert_eq!(test_macro.statements.len(), 1);
+
+    if let StatementType::Label(label) = &test_macro.statements[0].ty {
+        // Inside the label, __NOOP should be skipped, only the literal remains
+        assert_eq!(label.inner.len(), 1);
+        assert_eq!(label.name, "my_label");
+        assert_eq!(label.inner[0].ty, StatementType::Literal(str_to_bytes32("01")));
+    } else {
+        panic!("Expected Label statement");
+    }
+}
+
+#[test]
+fn test_parses_multiple_noops_in_sequence() {
+    let source = r#"#define macro TEST() = takes(0) returns(0) {
+            __NOOP
+            __NOOP
+            0x42
+            __NOOP
+        }"#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+    let test_macro = contract.macros.iter().find(|m| m.1.name == "TEST").unwrap().1;
+
+    // All __NOOP instances should be skipped, only 0x42 should remain
+    assert_eq!(test_macro.statements.len(), 1);
+    assert_eq!(test_macro.statements[0].ty, StatementType::Literal(str_to_bytes32("42")));
+}

--- a/crates/utils/src/ast/huff.rs
+++ b/crates/utils/src/ast/huff.rs
@@ -318,7 +318,7 @@ impl Contract {
                             let new_value = str_to_bytes32(&format!("{old_p}"));
                             storage_pointers.push((const_name.to_string(), new_value));
                         }
-                        ConstVal::Bytes(_) | ConstVal::BuiltinFunctionCall(_) | ConstVal::Expression(_) => {
+                        ConstVal::Bytes(_) | ConstVal::BuiltinFunctionCall(_) | ConstVal::Expression(_) | ConstVal::Noop => {
                             // Skip constants that are not free storage pointers
                         }
                         // This should never be reached, as we only assign free storage pointers
@@ -789,6 +789,10 @@ pub enum MacroArg {
     ///
     /// Example: `APPLY_OP(add)`, `USE_TWO_OPS(tload, clz)`
     Opcode(Opcode),
+    /// __NOOP builtin constant (generates no bytecode)
+    ///
+    /// Example: `MACRO(__NOOP)`
+    Noop,
 }
 
 /// An argument call
@@ -900,6 +904,8 @@ pub enum ConstVal {
     BuiltinFunctionCall(BuiltinFunctionCall),
     /// An arithmetic expression (evaluated at compile time)
     Expression(Expression),
+    /// __NOOP builtin constant (generates no bytecode)
+    Noop,
 }
 
 /// A Constant Definition

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -35,6 +35,8 @@ pub enum ParserErrorKind {
     InvalidDefinition(TokenKind),
     /// Invalid constant value
     InvalidConstantValue(TokenKind),
+    /// Invalid constant name (reserved name)
+    InvalidConstantName,
     /// Unexpected token in macro body
     InvalidTokenInMacroBody(TokenKind),
     /// Unexpected token in label definition
@@ -450,6 +452,9 @@ impl fmt::Display for CompilerError {
                 }
                 ParserErrorKind::InvalidConstantValue(cv) => {
                     write!(f, "\nError at token {}: Invalid Constant Value: \"{}\" \n{}\n", pe.cursor, cv, pe.spans.error(pe.hint.as_ref()))
+                }
+                ParserErrorKind::InvalidConstantName => {
+                    write!(f, "\nError at token {}: Invalid Constant Name \n{}\n", pe.cursor, pe.spans.error(pe.hint.as_ref()))
                 }
                 ParserErrorKind::InvalidTokenInMacroBody(tmb) => {
                     write!(

--- a/crates/utils/src/token.rs
+++ b/crates/utils/src/token.rs
@@ -68,6 +68,8 @@ pub enum TokenKind {
     Indexed,
     /// "FREE_STORAGE_POINTER()" keyword
     FreeStoragePointer,
+    /// "__NOOP" builtin constant
+    Noop,
     /// An Identifier
     Ident(String),
     /// Equal Sign
@@ -187,6 +189,7 @@ impl fmt::Display for TokenKind {
             TokenKind::Takes => "takes",
             TokenKind::Returns => "returns",
             TokenKind::FreeStoragePointer => "FREE_STORAGE_POINTER()",
+            TokenKind::Noop => "__NOOP",
             TokenKind::Ident(s) => return write!(f, "{s}"),
             TokenKind::Assign => "=",
             TokenKind::OpenParen => "(",


### PR DESCRIPTION
- Add `__NOOP` builtin constant that generates no bytecode (fixes #111).
  - Can be used e.g. for optional macro arguments `MACRO(__NOOP)`.