### PR TITLE
feat: add support for `__ASSERT_PC` to assert current bytecode position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+
+## [1.4.0] - 2025-11-02
 - Add compile-time for-loops that expand during compilation.
   - Syntax: `for(variable in start..end) { body }` or `for(variable in start..end step N) { body }`
   - Support for a loop variable with `<variable>`.
     - Example: `for(i in 0..5) { <i> }` expands to `0x00 0x01 0x02 0x03 0x04`
-- Add `__NOOP` builtin constant that generates no bytecode.
+- Add `__NOOP` builtin constant that generates no bytecode (fixes #111).
   - Can be used e.g. for optional macro arguments `MACRO(__NOOP)`.
+- Add `__ASSERT_PC(<literal>|<constant>)` builtin function for compile-time bytecode position assertions.
+  - Useful for ensuring `JUMPDEST` are at expected offsets.
 
 ## [1.3.10] - 2025-11-01
 - Fix macro argument scoping to prevent arguments from leaking into nested macros that don't receive them (fixes #108).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "hnc"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "alloy-primitives",
  "assert_cmd",
@@ -4164,7 +4164,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "huff-neo-codegen"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-core"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-js"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "huff-neo-core",
  "huff-neo-utils",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-lexer"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "huff-neo-utils",
  "lazy_static",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-parser"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "alloy-primitives",
  "huff-neo-lexer",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-test-runner"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-utils"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/foundry-rs/huff-neo"
 rust-version = "1.89"
-version = "1.3.10"
+version = "1.4.0"
 
 [workspace.dependencies]
 huff-neo-codegen = { path = "crates/codegen" }

--- a/crates/codegen/src/irgen/constants.rs
+++ b/crates/codegen/src/irgen/constants.rs
@@ -1,4 +1,5 @@
 use crate::Codegen;
+use alloy_primitives::U256;
 use huff_neo_utils::ast::span::AstSpan;
 use huff_neo_utils::prelude::{
     CodegenError, CodegenErrorKind, ConstVal, ConstantDefinition, Contract, EVMVersion, literal_gen, str_to_bytes32,
@@ -55,4 +56,74 @@ pub fn lookup_constant(name: &str, contract: &Contract, ir_byte_span: &AstSpan) 
         });
     };
     Ok(constant)
+}
+
+/// Evaluates a constant to its numeric value as a usize
+///
+/// This is useful for builtin functions that need numeric constant values
+/// (e.g., __ASSERT_PC) without generating bytecode.
+///
+/// Returns an error if:
+/// - The constant doesn't exist
+/// - The constant is __NOOP (has no numeric value)
+/// - The constant is a builtin function call
+/// - The constant value exceeds usize::MAX
+pub fn evaluate_constant_value(name: &str, contract: &Contract, span: &AstSpan) -> Result<usize, CodegenError> {
+    let constant = lookup_constant(name, contract, span)?;
+
+    let literal = match &constant.value {
+        ConstVal::Bytes(bytes) => str_to_bytes32(&bytes.0),
+        ConstVal::Expression(expr) => {
+            tracing::info!(target: "codegen", "EVALUATING CONSTANT EXPRESSION \"{}\" FOR NUMERIC VALUE", constant.name);
+            contract.evaluate_constant_expression(expr)?
+        }
+        ConstVal::StoragePointer(lit) => *lit,
+        ConstVal::Noop => {
+            return Err(CodegenError {
+                kind: CodegenErrorKind::InvalidArguments(format!(
+                    "Constant [{}] is __NOOP which has no numeric value and cannot be used as a bytecode position",
+                    name
+                )),
+                span: span.clone_box(),
+                token: None,
+            });
+        }
+        ConstVal::BuiltinFunctionCall(bf) => {
+            return Err(CodegenError {
+                kind: CodegenErrorKind::InvalidArguments(format!(
+                    "Constant [{}] is a builtin function call ({}) which cannot be evaluated to a numeric position. \
+                     Only literal values, arithmetic expressions, and storage pointers are supported for __ASSERT_PC",
+                    name, bf.kind
+                )),
+                span: span.clone_box(),
+                token: None,
+            });
+        }
+        ConstVal::FreeStoragePointer(_) => {
+            return Err(CodegenError { kind: CodegenErrorKind::StoragePointersNotDerived, span: span.clone_box(), token: None });
+        }
+    };
+
+    // Convert [u8; 32] to U256, then to usize
+    let value = U256::from_be_bytes(literal);
+
+    // Check if value fits in usize
+    // Note: usize is sufficient for bytecode positions because in realistic scenarios,
+    // EVM contract bytecode size is limited by the block gas limit and the 24KB contract
+    // size limit (EIP-170).
+    if value > U256::from(usize::MAX) {
+        return Err(CodegenError {
+            kind: CodegenErrorKind::InvalidArguments(format!(
+                "Constant [{}] value ({}) exceeds maximum bytecode position size ({}). \
+                 Bytecode positions must fit within a usize for the target platform",
+                name,
+                value,
+                usize::MAX
+            )),
+            span: span.clone_box(),
+            token: None,
+        });
+    }
+
+    Ok(value.to::<usize>())
 }

--- a/crates/lexer/tests/builtins.rs
+++ b/crates/lexer/tests/builtins.rs
@@ -1,11 +1,20 @@
 use huff_neo_lexer::*;
 use huff_neo_utils::file::full_file_source::FullFileSource;
-use huff_neo_utils::prelude::{Span, Token, TokenKind};
+use huff_neo_utils::prelude::*;
 
 #[test]
 fn parses_builtin_function_in_macro_body() {
-    let builtin_funcs =
-        ["__codesize", "__tablesize", "__tablestart", "__FUNC_SIG", "__EVENT_HASH", "__ERROR", "__RIGHTPAD", "__CODECOPY_DYN_ARG"];
+    let builtin_funcs = [
+        "__codesize",
+        "__tablesize",
+        "__tablestart",
+        "__FUNC_SIG",
+        "__EVENT_HASH",
+        "__ERROR",
+        "__RIGHTPAD",
+        "__CODECOPY_DYN_ARG",
+        "__ASSERT_PC",
+    ];
 
     for builtin in builtin_funcs {
         let source = &format!(
@@ -65,8 +74,17 @@ fn parses_builtin_function_in_macro_body() {
 #[test]
 #[should_panic]
 fn fails_to_parse_builtin_outside_macro_body() {
-    let builtin_funcs =
-        ["__codesize", "__tablesize", "__tablestart", "__FUNC_SIG", "__EVENT_HASH", "__ERROR", "__RIGHTPAD", "__CODECOPY_DYN_ARG"];
+    let builtin_funcs = [
+        "__codesize",
+        "__tablesize",
+        "__tablestart",
+        "__FUNC_SIG",
+        "__EVENT_HASH",
+        "__ERROR",
+        "__RIGHTPAD",
+        "__CODECOPY_DYN_ARG",
+        "__ASSERT_PC",
+    ];
 
     for builtin in builtin_funcs {
         let source = &format!("{builtin}(MAIN)");
@@ -160,4 +178,128 @@ fn parses_builtin_function_in_macro_body_nested() {
     assert_eq!(tokens.len(), 2);
     assert_eq!(tokens[0].kind, TokenKind::BuiltinFunction("__RIGHTPAD".to_string()));
     assert_eq!(tokens[1].kind, TokenKind::BuiltinFunction("__FUNC_SIG".to_string()));
+}
+
+#[test]
+fn parses_assert_pc_with_literal() {
+    let source = r#"
+        #define macro TEST() = takes(0) returns(0) {
+            __ASSERT_PC(0x00)
+        }
+    "#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+
+    // Check __ASSERT_PC token
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    assert_eq!(unwrapped.kind, TokenKind::BuiltinFunction("__ASSERT_PC".to_string()));
+
+    let _ = lexer.next(); // open parenthesis
+
+    // Check literal argument
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    assert_eq!(unwrapped.kind, TokenKind::Literal(str_to_bytes32("00")));
+
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // eof
+
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_assert_pc_with_constant() {
+    let source = r#"
+        #define constant TARGET_PC = 0x10
+        #define macro TEST() = takes(0) returns(0) {
+            __ASSERT_PC([TARGET_PC])
+        }
+    "#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Skip to the macro body
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // constant
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TARGET_PC
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // 0x10
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+
+    // Check __ASSERT_PC token
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    assert_eq!(unwrapped.kind, TokenKind::BuiltinFunction("__ASSERT_PC".to_string()));
+
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // [
+
+    // Check constant reference
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    assert_eq!(unwrapped.kind, TokenKind::Ident("TARGET_PC".to_string()));
+
+    let _ = lexer.next(); // ]
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // eof
+
+    assert!(lexer.eof);
 }

--- a/crates/parser/tests/macro.rs
+++ b/crates/parser/tests/macro.rs
@@ -1190,3 +1190,130 @@ fn test_duplicate_macro_error() {
         }
     }
 }
+
+#[test]
+fn macro_with_assert_pc_literal() {
+    let source = r#"
+    #define macro TEST() = takes(0) returns(0) {
+        __ASSERT_PC(0x00)
+    }
+    "#;
+
+    // Parse tokens
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let macro_definition = parser.parse().unwrap().macros.get("TEST").cloned().unwrap();
+    let expected = MacroDefinition {
+        name: "TEST".to_string(),
+        decorator: None,
+        parameters: vec![],
+        statements: vec![Statement {
+            ty: StatementType::BuiltinFunctionCall(BuiltinFunctionCall {
+                kind: BuiltinFunctionKind::AssertPc,
+                args: vec![BuiltinFunctionArg::Argument(Argument {
+                    arg_type: None,
+                    arg_location: None,
+                    name: Some("00".to_string()),
+                    indexed: false,
+                    span: AstSpan(vec![Span { start: 70, end: 74, file: None }]),
+                })],
+                span: AstSpan(vec![Span { start: 58, end: 69, file: None }, Span { start: 70, end: 74, file: None }]),
+            }),
+            span: AstSpan(vec![Span { start: 58, end: 69, file: None }, Span { start: 70, end: 74, file: None }]),
+        }],
+        takes: 0,
+        returns: 0,
+        span: AstSpan(vec![
+            Span { start: 5, end: 12, file: None },
+            Span { start: 13, end: 18, file: None },
+            Span { start: 19, end: 23, file: None },
+            Span { start: 23, end: 24, file: None },
+            Span { start: 24, end: 25, file: None },
+            Span { start: 26, end: 27, file: None },
+            Span { start: 28, end: 33, file: None },
+            Span { start: 33, end: 34, file: None },
+            Span { start: 34, end: 35, file: None },
+            Span { start: 35, end: 36, file: None },
+            Span { start: 37, end: 44, file: None },
+            Span { start: 44, end: 45, file: None },
+            Span { start: 45, end: 46, file: None },
+            Span { start: 46, end: 47, file: None },
+            Span { start: 48, end: 49, file: None },
+            Span { start: 58, end: 69, file: None },
+            Span { start: 69, end: 70, file: None },
+            Span { start: 70, end: 74, file: None },
+            Span { start: 74, end: 75, file: None },
+            Span { start: 80, end: 81, file: None },
+        ]),
+        outlined: false,
+        test: false,
+    };
+
+    assert_eq!(macro_definition, expected);
+}
+
+#[test]
+fn macro_with_assert_pc_constant() {
+    let source = r#"
+    #define constant TARGET_PC = 0x10
+    #define macro TEST() = takes(0) returns(0) {
+        __ASSERT_PC([TARGET_PC])
+    }
+    "#;
+
+    // Parse tokens
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let macro_definition = parser.parse().unwrap().macros.get("TEST").cloned().unwrap();
+    let expected = MacroDefinition {
+        name: "TEST".to_string(),
+        decorator: None,
+        parameters: vec![],
+        statements: vec![Statement {
+            ty: StatementType::BuiltinFunctionCall(BuiltinFunctionCall {
+                kind: BuiltinFunctionKind::AssertPc,
+                args: vec![BuiltinFunctionArg::Constant("TARGET_PC".to_string(), AstSpan(vec![Span { start: 108, end: 119, file: None }]))],
+                span: AstSpan(vec![Span { start: 96, end: 107, file: None }, Span { start: 108, end: 119, file: None }]),
+            }),
+            span: AstSpan(vec![Span { start: 96, end: 107, file: None }, Span { start: 108, end: 119, file: None }]),
+        }],
+        takes: 0,
+        returns: 0,
+        span: AstSpan(vec![
+            Span { start: 43, end: 50, file: None },
+            Span { start: 51, end: 56, file: None },
+            Span { start: 57, end: 61, file: None },
+            Span { start: 61, end: 62, file: None },
+            Span { start: 62, end: 63, file: None },
+            Span { start: 64, end: 65, file: None },
+            Span { start: 66, end: 71, file: None },
+            Span { start: 71, end: 72, file: None },
+            Span { start: 72, end: 73, file: None },
+            Span { start: 73, end: 74, file: None },
+            Span { start: 75, end: 82, file: None },
+            Span { start: 82, end: 83, file: None },
+            Span { start: 83, end: 84, file: None },
+            Span { start: 84, end: 85, file: None },
+            Span { start: 86, end: 87, file: None },
+            Span { start: 96, end: 107, file: None },
+            Span { start: 107, end: 108, file: None },
+            Span { start: 108, end: 109, file: None },
+            Span { start: 109, end: 118, file: None },
+            Span { start: 118, end: 119, file: None },
+            Span { start: 119, end: 120, file: None },
+            Span { start: 125, end: 126, file: None },
+        ]),
+        outlined: false,
+        test: false,
+    };
+
+    assert_eq!(macro_definition, expected);
+}

--- a/crates/utils/src/ast/huff.rs
+++ b/crates/utils/src/ast/huff.rs
@@ -1008,6 +1008,8 @@ pub enum BuiltinFunctionKind {
     Verbatim,
     /// Bytes function to convert a string to bytes
     Bytes,
+    /// Assert PC (program counter) position
+    AssertPc,
 }
 
 impl From<String> for BuiltinFunctionKind {
@@ -1024,6 +1026,7 @@ impl From<String> for BuiltinFunctionKind {
             "__CODECOPY_DYN_ARG" => BuiltinFunctionKind::DynConstructorArg,
             "__VERBATIM" => BuiltinFunctionKind::Verbatim,
             "__BYTES" => BuiltinFunctionKind::Bytes,
+            "__ASSERT_PC" => BuiltinFunctionKind::AssertPc,
             _ => panic!("Invalid Builtin Function Kind"), /* This should never be reached,
                                                            * builtins are validated with a
                                                            * `try_from` call in the lexer. */
@@ -1047,6 +1050,7 @@ impl TryFrom<&String> for BuiltinFunctionKind {
             "__CODECOPY_DYN_ARG" => Ok(BuiltinFunctionKind::DynConstructorArg),
             "__VERBATIM" => Ok(BuiltinFunctionKind::Verbatim),
             "__BYTES" => Ok(BuiltinFunctionKind::Bytes),
+            "__ASSERT_PC" => Ok(BuiltinFunctionKind::AssertPc),
             _ => Err(()),
         }
     }
@@ -1066,6 +1070,7 @@ impl Display for BuiltinFunctionKind {
             BuiltinFunctionKind::DynConstructorArg => write!(f, "__CODECOPY_DYN_ARG"),
             BuiltinFunctionKind::Verbatim => write!(f, "__VERBATIM"),
             BuiltinFunctionKind::Bytes => write!(f, "__BYTES"),
+            BuiltinFunctionKind::AssertPc => write!(f, "__ASSERT_PC"),
         }
     }
 }

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -244,6 +244,8 @@ pub enum CodegenErrorKind {
     InvalidLoopStep,
     /// Loop iteration limit exceeded (contains max limit)
     LoopIterationLimitExceeded(usize),
+    /// PC (program counter) assertion failed (expected, actual)
+    AssertPcFailed(usize, usize),
 }
 
 impl Spanned for CodegenError {
@@ -362,6 +364,9 @@ impl<W: Write> Report<W> for CodegenError {
             }
             CodegenErrorKind::LoopIterationLimitExceeded(max) => {
                 write!(f.out, "Loop iteration limit exceeded: maximum {} iterations allowed at compile-time", max)
+            }
+            CodegenErrorKind::AssertPcFailed(expected, actual) => {
+                write!(f.out, "PC assertion failed: expected position 0x{:x}, but current position is 0x{:x}", expected, actual)
             }
         }
     }
@@ -704,6 +709,15 @@ impl fmt::Display for CompilerError {
                         f,
                         "\nError: Loop iteration limit exceeded\nMaximum {} iterations allowed at compile-time\n{}\n",
                         max,
+                        ce.span.error(None)
+                    )
+                }
+                CodegenErrorKind::AssertPcFailed(expected, actual) => {
+                    write!(
+                        f,
+                        "\nError: PC assertion failed\nExpected position: 0x{:x}\nActual position: 0x{:x}\n{}\n",
+                        expected,
+                        actual,
                         ce.span.error(None)
                     )
                 }


### PR DESCRIPTION
- Add `__ASSERT_PC(<literal>|<constant>)` builtin function for compile-time bytecode position assertions.
  - Useful for ensuring `JUMPDEST` are at expected offsets.