### PR TITLE
fix: constant values require brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## Unreleased
 
+## [1.5.0] - 2025-11-02
+- **Breaking**: Bracket notation `[CONSTANT_NAME]` is now required for referencing constants in arithmetic expressions and for-loop bounds (fixes #115).
+  - Example: `#define constant RESULT = [A] + [B]` (was: `A + B`)
+  - This follow the Huff language convention for constant values using brackets.
+  - Applies to: constant definitions with arithmetic expressions, for-loop bounds (`for(i in [START]..[END])`), and for-loop step values.
+  - Migration: Update code from `for(i in START..END)` to `for(i in [START]..[END])` and arithmetic expressions from `A + B` to `[A] + [B]`.
+
 ## [1.4.0] - 2025-11-02
 - Add compile-time for-loops that expand during compilation.
   - Syntax: `for(variable in start..end) { body }` or `for(variable in start..end step N) { body }`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "hnc"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "alloy-primitives",
  "assert_cmd",
@@ -4164,7 +4164,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "huff-neo-codegen"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-core"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-js"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "huff-neo-core",
  "huff-neo-utils",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-lexer"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "huff-neo-utils",
  "lazy_static",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-parser"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "alloy-primitives",
  "huff-neo-lexer",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-test-runner"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-utils"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/foundry-rs/huff-neo"
 rust-version = "1.89"
-version = "1.4.0"
+version = "1.5.0"
 
 [workspace.dependencies]
 huff-neo-codegen = { path = "crates/codegen" }

--- a/book/get-started/comparison-to-huff-rs.md
+++ b/book/get-started/comparison-to-huff-rs.md
@@ -28,10 +28,10 @@ Constants can use arithmetic expressions evaluated at compile time.
 ```javascript
 #define constant BASE = 0x20
 #define constant OFFSET = 0x04
-#define constant COMBINED = BASE + OFFSET          // 0x24
+#define constant COMBINED = [BASE] + [OFFSET]      // 0x24
 
 #define constant WORD_SIZE = 0x20
-#define constant HALF_WORD = WORD_SIZE / 0x02      // 0x10
+#define constant HALF_WORD = [WORD_SIZE] / 0x02    // 0x10
 
 #define constant COMPLEX = (0x0a + 0x05) * 0x02    // 0x1e
 ```
@@ -74,14 +74,19 @@ There are new builtin functions available in `huff-neo`.
 
 #### `__ASSERT_PC()` example
 
-Validates that bytecode is positioned at expected offsets, useful for ensuring jump destinations align correctly.
+Validates that bytecode is positioned at expected offsets, useful for ensuring jump destinations align correctly. Can be combined with for-loops and constants for precise bytecode positioning.
 
 ```javascript
 #define constant TARGET_OFFSET = 0x20
 
 #define macro MAIN() = takes(0) returns(0) {
     __ASSERT_PC(0x00)           // Assert we're at the start
-    // ... 32 bytes of code ...
+
+    // Fill space to reach target offset using for-loop with constant
+    for(i in 0..[TARGET_OFFSET]) {
+        stop  // Expands to 32 stop instructions = 32 bytes
+    }
+
     __ASSERT_PC([TARGET_OFFSET]) // Assert we're at byte 32
     target:                      // Label for jump destination
 }
@@ -116,7 +121,7 @@ Generate repetitive code patterns at compile-time using for loops that expand be
 
 #define macro INIT_STORAGE() = takes(0) returns(0) {
     // Initialize storage slots 0 through 9 with zero
-    for(i in 0..COUNT) {
+    for(i in 0..[COUNT]) {
         0x00 <i> sstore
     }
 }

--- a/book/huff-language/builtin-functions.md
+++ b/book/huff-language/builtin-functions.md
@@ -69,16 +69,15 @@ This is useful for ensuring critical instructions (like jump destinations) are p
 }
 ```
 
-You can also use constants:
+You can also use constants and combine with for-loops:
 ```javascript
 #define constant TARGET_OFFSET = 0x20
 
 #define macro MAIN() = takes (0) returns (0) {
-    // Fill space to reach target offset
-    stop stop stop stop stop stop stop stop  // 8 bytes
-    stop stop stop stop stop stop stop stop  // 8 bytes
-    stop stop stop stop stop stop stop stop  // 8 bytes
-    stop stop stop stop stop stop stop stop  // 8 bytes
+    // Fill space to reach target offset using for-loop with constant
+    for(i in 0..[TARGET_OFFSET]) {
+        stop  // Expands to 32 stop instructions = 32 bytes
+    }
     __ASSERT_PC([TARGET_OFFSET])  // Ensure we're at the expected offset (0x20 = 32 bytes)
     important_label:             // Label generates JUMPDEST automatically
 }

--- a/book/huff-language/compile-time-loops.md
+++ b/book/huff-language/compile-time-loops.md
@@ -100,6 +100,25 @@ for(i in 0..3) {
 
 Loop bounds must be constant expressions that can be evaluated at compile-time.
 
+### Constant References
+
+When referencing constants in loop bounds or step values, you **must** use bracket notation `[CONSTANT_NAME]`:
+
+```javascript
+#define constant END = 10
+
+// ✓ Correct - bracket notation required
+for(i in 0..[END]) { }
+
+// ✗ Incorrect - bare constant name not allowed
+for(i in 0..END) { }
+```
+
+This applies to all positions where constants appear:
+- Start bound: `for(i in [START]..end)`
+- End bound: `for(i in start..[END])`
+- Step value: `for(i in start..end step [STEP])`
+
 ### U256 Range Support
 
 Loop ranges support **full u256 values** using hex notation:
@@ -110,7 +129,7 @@ Loop ranges support **full u256 values** using hex notation:
 #define constant STEP = 0x10
 
 #define macro USE_CONSTANTS() = takes(0) returns(16) {
-    for(i in START..END step STEP) {
+    for(i in [START]..[END] step [STEP]) {
         <i>
     }
 }
@@ -132,7 +151,7 @@ You can use arithmetic expressions:
 ```javascript
 #define constant SIZE = 5
 
-for(i in 0..SIZE * 2) {
+for(i in 0..[SIZE] * 2) {
     <i>
 }
 // Expands iterations from 0 to 9
@@ -209,7 +228,7 @@ loop:
     loop jumpi
 
 // Compile-time loop (no runtime overhead)
-for(i in 0..COUNT) {
+for(i in 0..[COUNT]) {
     // ... unrolled code
 }
 ```
@@ -230,8 +249,8 @@ for(i in 0..COUNT) {
 #define constant MATRIX_SIZE = 4
 
 #define macro INIT_MATRIX() = takes(0) returns(0) {
-    for(row in 0..MATRIX_SIZE) {
-        for(col in 0..MATRIX_SIZE) {
+    for(row in 0..[MATRIX_SIZE]) {
+        for(col in 0..[MATRIX_SIZE]) {
             0x00
             <row>
             <col>
@@ -249,7 +268,7 @@ for(i in 0..COUNT) {
 
 #define macro COPY_ARRAY() = takes(2) returns(0) {
     // Takes: source_ptr dest_ptr
-    for(offset in 0..ARRAY_LENGTH step 0x20) {
+    for(offset in 0..[ARRAY_LENGTH] step 0x20) {
         // Load from source
         dup2 <offset> add mload
         // Store to dest

--- a/book/huff-language/constants.md
+++ b/book/huff-language/constants.md
@@ -56,12 +56,12 @@ Use parentheses to override precedence.
 ```javascript
 #define constant BASE = 0x20
 #define constant OFFSET = 0x04
-#define constant COMBINED = BASE + OFFSET          // Result: 0x24
+#define constant COMBINED = [BASE] + [OFFSET]      // Result: 0x24
 
 #define constant TEN = 0x0a
 #define constant FIVE = 0x05
-#define constant SIMPLE_ADD = TEN + FIVE            // Result: 0x0f
-#define constant SIMPLE_SUB = TEN - FIVE            // Result: 0x05
+#define constant SIMPLE_ADD = [TEN] + [FIVE]        // Result: 0x0f
+#define constant SIMPLE_SUB = [TEN] - [FIVE]        // Result: 0x05
 
 #define constant MULTIPLY = 0x03 * 0x04             // Result: 0x0c
 #define constant DIVIDE = 0x10 / 0x02               // Result: 0x08
@@ -70,8 +70,8 @@ Use parentheses to override precedence.
 
 **Complex Expressions:**
 ```javascript
-#define constant COMPLEX = (TEN + FIVE) * 0x02     // Result: 0x1e (30 in decimal)
-#define constant NESTED = BASE + (OFFSET * 0x02)   // Result: 0x28
+#define constant COMPLEX = ([TEN] + [FIVE]) * 0x02 // Result: 0x1e (30 in decimal)
+#define constant NESTED = [BASE] + ([OFFSET] * 0x02) // Result: 0x28
 
 // Precedence: multiplication before addition
 #define constant PRECEDENCE = 0x02 + 0x03 * 0x04   // Result: 0x0e (2 + 12)
@@ -83,7 +83,7 @@ Use parentheses to override precedence.
 **Negation:**
 ```javascript
 #define constant POSITIVE = 0x0a
-#define constant NEGATIVE = -POSITIVE               // Result: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6
+#define constant NEGATIVE = -[POSITIVE]             // Result: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6
 
 // Negation in expressions
 #define constant MIXED = -0x05 + 0x0a               // Result: 0x05
@@ -94,29 +94,29 @@ Use parentheses to override precedence.
 **Storage Slots:**
 ```javascript
 #define constant STORAGE_SLOT_0 = 0x00
-#define constant STORAGE_SLOT_1 = STORAGE_SLOT_0 + 0x01
-#define constant STORAGE_SLOT_2 = STORAGE_SLOT_0 + 0x02
+#define constant STORAGE_SLOT_1 = [STORAGE_SLOT_0] + 0x01
+#define constant STORAGE_SLOT_2 = [STORAGE_SLOT_0] + 0x02
 ```
 
 **Memory Offsets:**
 ```javascript
 #define constant MEM_OFFSET_0 = 0x00
-#define constant MEM_OFFSET_32 = MEM_OFFSET_0 + 0x20
-#define constant MEM_OFFSET_64 = MEM_OFFSET_32 + 0x20
+#define constant MEM_OFFSET_32 = [MEM_OFFSET_0] + 0x20
+#define constant MEM_OFFSET_64 = [MEM_OFFSET_32] + 0x20
 ```
 
 **Size Computations:**
 ```javascript
 #define constant WORD_SIZE = 0x20
-#define constant HALF_WORD = WORD_SIZE / 0x02
-#define constant DOUBLE_WORD = WORD_SIZE * 0x02
+#define constant HALF_WORD = [WORD_SIZE] / 0x02
+#define constant DOUBLE_WORD = [WORD_SIZE] * 0x02
 ```
 
 **ABI Encoding:**
 ```javascript
 #define constant SELECTOR_SIZE = 0x04
 #define constant FIRST_ARG_OFFSET = SELECTOR_SIZE
-#define constant SECOND_ARG_OFFSET = SELECTOR_SIZE + 0x20
+#define constant SECOND_ARG_OFFSET = [SELECTOR_SIZE] + 0x20
 ```
 
 ### Compile-Time Evaluation
@@ -126,7 +126,7 @@ Expressions are evaluated during compilation. The compiler replaces the expressi
 ```javascript
 #define constant A = 0x10
 #define constant B = 0x05
-#define constant C = A + B    // Evaluated to 0x15 at compile time
+#define constant C = [A] + [B]  // Evaluated to 0x15 at compile time
 
 #define macro EXAMPLE() = takes(0) returns(0) {
     [C]    // Compiles to: PUSH1 0x15

--- a/crates/core/tests/arithmetic_expressions.rs
+++ b/crates/core/tests/arithmetic_expressions.rs
@@ -10,7 +10,7 @@ fn test_simple_addition() {
     let source = r#"
         #define constant A = 0x10
         #define constant B = 0x05
-        #define constant RESULT = A + B  // 0x15
+        #define constant RESULT = [A] + [B]  // 0x15
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -26,7 +26,7 @@ fn test_simple_subtraction() {
     let source = r#"
         #define constant A = 0x20
         #define constant B = 0x08
-        #define constant RESULT = A - B  // 0x18
+        #define constant RESULT = [A] - [B]  // 0x18
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -42,7 +42,7 @@ fn test_simple_multiplication() {
     let source = r#"
         #define constant A = 0x03
         #define constant B = 0x07
-        #define constant RESULT = A * B  // 0x15
+        #define constant RESULT = [A] * [B]  // 0x15
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -58,7 +58,7 @@ fn test_simple_division() {
     let source = r#"
         #define constant A = 0x64  // 100
         #define constant B = 0x0a  // 10
-        #define constant RESULT = A / B  // 0x0a
+        #define constant RESULT = [A] / [B]  // 0x0a
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -74,7 +74,7 @@ fn test_simple_modulo() {
     let source = r#"
         #define constant A = 0x0a  // 10
         #define constant B = 0x03  // 3
-        #define constant RESULT = A % B  // 0x01
+        #define constant RESULT = [A] % [B]  // 0x01
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -89,7 +89,7 @@ fn test_simple_modulo() {
 fn test_unary_negation() {
     let source = r#"
         #define constant A = 0x05
-        #define constant RESULT = -A  // Two's complement of 5
+        #define constant RESULT = -[A]  // Two's complement of 5
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -109,7 +109,7 @@ fn test_operator_precedence_mul_before_add() {
         #define constant A = 0x02
         #define constant B = 0x03
         #define constant C = 0x04
-        #define constant RESULT = A + B * C  // 2 + (3 * 4) = 14 = 0x0e
+        #define constant RESULT = [A] + [B] * [C]  // 2 + (3 * 4) = 14 = 0x0e
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -154,7 +154,7 @@ fn test_parenthesized_expression_override_precedence() {
         #define constant A = 0x02
         #define constant B = 0x03
         #define constant C = 0x04
-        #define constant RESULT = (A + B) * C  // (2 + 3) * 4 = 20 = 0x14
+        #define constant RESULT = ([A] + [B]) * [C]  // (2 + 3) * 4 = 20 = 0x14
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -172,7 +172,7 @@ fn test_nested_parentheses() {
         #define constant B = 0x02
         #define constant C = 0x03
         #define constant D = 0x04
-        #define constant RESULT = ((A + B) * (C + D))  // (1+2) * (3+4) = 3 * 7 = 21 = 0x15
+        #define constant RESULT = (([A] + [B]) * ([C] + [D]))  // (1+2) * (3+4) = 3 * 7 = 21 = 0x15
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -187,7 +187,7 @@ fn test_nested_parentheses() {
 fn test_deeply_nested_parentheses() {
     let source = r#"
         #define constant A = 0x05
-        #define constant RESULT = ((((A))))  // Should just be 5
+        #define constant RESULT = (((([A]))))  // Should just be 5
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -250,7 +250,7 @@ fn test_complex_expression_with_constants() {
         #define constant BASE = 0x20
         #define constant OFFSET = 0x04
         #define constant MULTIPLIER = 0x02
-        #define constant RESULT = BASE + (OFFSET * MULTIPLIER)  // 32 + (4 * 2) = 40 = 0x28
+        #define constant RESULT = [BASE] + ([OFFSET] * [MULTIPLIER])  // 32 + (4 * 2) = 40 = 0x28
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -267,7 +267,7 @@ fn test_all_operators_combined() {
         #define constant A = 0x0a  // 10
         #define constant B = 0x03  // 3
         #define constant C = 0x02  // 2
-        #define constant RESULT = ((A + B) * C - 0x04) / 0x05  // ((10+3)*2-4)/5 = (26-4)/5 = 22/5 = 4
+        #define constant RESULT = (([A] + [B]) * [C] - 0x04) / 0x05  // ((10+3)*2-4)/5 = (26-4)/5 = 22/5 = 4
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -298,10 +298,10 @@ fn test_mixed_precedence_levels() {
 fn test_chained_constant_references() {
     let source = r#"
         #define constant A = 0x01
-        #define constant B = A + 0x01  // 2
-        #define constant C = B + 0x01  // 3
-        #define constant D = C + 0x01  // 4
-        #define constant RESULT = A + B + C + D  // 1 + 2 + 3 + 4 = 10 = 0x0a
+        #define constant B = [A] + 0x01  // 2
+        #define constant C = [B] + 0x01  // 3
+        #define constant D = [C] + 0x01  // 4
+        #define constant RESULT = [A] + [B] + [C] + [D]  // 1 + 2 + 3 + 4 = 10 = 0x0a
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -332,8 +332,8 @@ fn test_hex_literal_in_expression() {
 fn test_double_negation() {
     let source = r#"
         #define constant A = 0x05
-        #define constant NEG_A = -A
-        #define constant RESULT = -NEG_A  // --5 = 5
+        #define constant NEG_A = -[A]
+        #define constant RESULT = -[NEG_A]  // --5 = 5
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -349,7 +349,7 @@ fn test_negation_in_expression() {
     let source = r#"
         #define constant A = 0x05
         #define constant B = 0x03
-        #define constant RESULT = B + -A  // 3 + (-5) - tests negation as operand
+        #define constant RESULT = [B] + -[A]  // 3 + (-5) - tests negation as operand
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -365,9 +365,9 @@ fn test_negation_in_expression() {
 fn test_zero_operations() {
     let source = r#"
         #define constant ZERO = 0x00
-        #define constant ADD_ZERO = 0x05 + ZERO  // 5
-        #define constant SUB_ZERO = 0x05 - ZERO  // 5
-        #define constant MUL_ZERO = 0x05 * ZERO  // 0
+        #define constant ADD_ZERO = 0x05 + [ZERO]  // 5
+        #define constant SUB_ZERO = 0x05 - [ZERO]  // 5
+        #define constant MUL_ZERO = 0x05 * [ZERO]  // 0
 
         #define macro MAIN() = takes(0) returns(0) {
             [ADD_ZERO]
@@ -385,7 +385,7 @@ fn test_zero_operations() {
 fn test_large_numbers() {
     let source = r#"
         #define constant LARGE_A = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-        #define constant RESULT = LARGE_A + 0x00  // Should handle max U256
+        #define constant RESULT = [LARGE_A] + 0x00  // Should handle max U256
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -465,7 +465,7 @@ fn test_constructor_with_expressions() {
 fn test_division_by_zero_error() {
     let source = r#"
         #define constant ZERO = 0x00
-        #define constant RESULT = 0x10 / ZERO
+        #define constant RESULT = 0x10 / [ZERO]
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -491,7 +491,7 @@ fn test_modulo_by_zero_error() {
 #[test]
 fn test_undefined_constant_error() {
     let source = r#"
-        #define constant RESULT = UNDEFINED_CONST + 0x01
+        #define constant RESULT = [UNDEFINED_CONST] + 0x01
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -505,7 +505,7 @@ fn test_undefined_constant_error() {
 fn test_overflow_error() {
     let source = r#"
         #define constant MAX = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-        #define constant RESULT = MAX + 0x01  // Should overflow
+        #define constant RESULT = [MAX] + 0x01  // Should overflow
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]
@@ -532,7 +532,7 @@ fn test_underflow_error() {
 fn test_multiplication_overflow() {
     let source = r#"
         #define constant LARGE = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-        #define constant RESULT = LARGE * 0x02  // Should overflow
+        #define constant RESULT = [LARGE] * 0x02  // Should overflow
 
         #define macro MAIN() = takes(0) returns(0) {
             [RESULT]

--- a/crates/core/tests/builtins.rs
+++ b/crates/core/tests/builtins.rs
@@ -580,7 +580,7 @@ fn test_assert_pc_with_arithmetic_expression() {
     let source: &str = r#"
         #define constant BASE = 0x02
         #define constant OFFSET = 0x02
-        #define constant TARGET_PC = BASE + OFFSET
+        #define constant TARGET_PC = [BASE] + [OFFSET]
         #define macro MAIN() = takes(0) returns(0) {
             0x01 0x02       // 4 bytes total
             __ASSERT_PC([TARGET_PC])  // Should evaluate to 0x04

--- a/crates/core/tests/for_loops.rs
+++ b/crates/core/tests/for_loops.rs
@@ -46,7 +46,7 @@ fn test_for_loop_with_constants() {
         #define constant END = 0x04
 
         #define macro MAIN() = takes(0) returns(0) {
-            for(i in START..END) {
+            for(i in [START]..[END]) {
                 <i>
             }
         }
@@ -67,7 +67,7 @@ fn test_for_loop_with_arithmetic_bounds() {
         #define constant MULTIPLIER = 0x03
 
         #define macro MAIN() = takes(0) returns(0) {
-            for(i in BASE..BASE*MULTIPLIER) {
+            for(i in [BASE]..[BASE]*[MULTIPLIER]) {
                 <i>
             }
         }
@@ -206,7 +206,7 @@ fn test_for_loop_with_constant_step() {
         #define constant STEP_SIZE = 0x02
 
         #define macro MAIN() = takes(0) returns(0) {
-            for(i in 0..6 step STEP_SIZE) {
+            for(i in 0..6 step [STEP_SIZE]) {
                 <i>
             }
         }

--- a/crates/core/tests/parser_errors.rs
+++ b/crates/core/tests/parser_errors.rs
@@ -116,7 +116,6 @@ fn test_invalid_constant_value() {
     let invalid_constant_values = vec![
         ("<", TokenKind::LeftAngle),
         ("{", TokenKind::OpenBrace),
-        ("[", TokenKind::OpenBracket),
         (":", TokenKind::Colon),
         (",", TokenKind::Comma),
         ("+", TokenKind::Add),

--- a/crates/lexer/tests/for_loops.rs
+++ b/crates/lexer/tests/for_loops.rs
@@ -289,7 +289,7 @@ fn parses_for_loop_with_hex_bounds() {
 
 #[test]
 fn parses_for_loop_with_constants() {
-    let source = "#define macro TEST() = takes(0) returns(0) { for(i in START..END) { } }";
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in [START]..[END]) { } }";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let mut lexer = Lexer::new(flattened_source);
 

--- a/crates/parser/tests/arithmetic_expressions.rs
+++ b/crates/parser/tests/arithmetic_expressions.rs
@@ -8,7 +8,7 @@ use huff_neo_utils::prelude::*;
 
 #[test]
 fn test_parse_simple_addition() {
-    let source = "#define constant RESULT = A + B";
+    let source = "#define constant RESULT = [A] + [B]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -20,13 +20,13 @@ fn test_parse_simple_addition() {
     let expected = ConstantDefinition {
         name: "RESULT".to_string(),
         value: ConstVal::Expression(Expression::Binary {
-            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 27, file: None }]) }),
+            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 29, file: None }]) }),
             op: BinaryOp::Add,
-            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 30, end: 31, file: None }]) }),
+            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 32, end: 35, file: None }]) }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None }, // "A"
-                Span { start: 28, end: 29, file: None }, // "+"
-                Span { start: 30, end: 31, file: None }, // "B"
+                Span { start: 26, end: 29, file: None }, // "[A]"
+                Span { start: 30, end: 31, file: None }, // "+"
+                Span { start: 32, end: 35, file: None }, // "[B]"
             ]),
         }),
         span: AstSpan(vec![
@@ -34,9 +34,13 @@ fn test_parse_simple_addition() {
             Span { start: 8, end: 16, file: None },  // "constant"
             Span { start: 17, end: 23, file: None }, // "RESULT"
             Span { start: 24, end: 25, file: None }, // "="
-            Span { start: 26, end: 27, file: None }, // "A"
-            Span { start: 28, end: 29, file: None }, // "+"
-            Span { start: 30, end: 31, file: None }, // "B"
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 28, file: None }, // "A"
+            Span { start: 28, end: 29, file: None }, // "]"
+            Span { start: 30, end: 31, file: None }, // "+"
+            Span { start: 32, end: 33, file: None }, // "["
+            Span { start: 33, end: 34, file: None }, // "B"
+            Span { start: 34, end: 35, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -44,7 +48,7 @@ fn test_parse_simple_addition() {
 
 #[test]
 fn test_parse_simple_subtraction() {
-    let source = "#define constant RESULT = A - B";
+    let source = "#define constant RESULT = [A] - [B]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -56,13 +60,13 @@ fn test_parse_simple_subtraction() {
     let expected = ConstantDefinition {
         name: "RESULT".to_string(),
         value: ConstVal::Expression(Expression::Binary {
-            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 27, file: None }]) }),
+            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 29, file: None }]) }),
             op: BinaryOp::Sub,
-            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 30, end: 31, file: None }]) }),
+            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 32, end: 35, file: None }]) }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None }, // "A"
-                Span { start: 28, end: 29, file: None }, // "-"
-                Span { start: 30, end: 31, file: None }, // "B"
+                Span { start: 26, end: 29, file: None }, // "[A]"
+                Span { start: 30, end: 31, file: None }, // "-"
+                Span { start: 32, end: 35, file: None }, // "[B]"
             ]),
         }),
         span: AstSpan(vec![
@@ -70,9 +74,13 @@ fn test_parse_simple_subtraction() {
             Span { start: 8, end: 16, file: None },  // "constant"
             Span { start: 17, end: 23, file: None }, // "RESULT"
             Span { start: 24, end: 25, file: None }, // "="
-            Span { start: 26, end: 27, file: None }, // "A"
-            Span { start: 28, end: 29, file: None }, // "-"
-            Span { start: 30, end: 31, file: None }, // "B"
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 28, file: None }, // "A"
+            Span { start: 28, end: 29, file: None }, // "]"
+            Span { start: 30, end: 31, file: None }, // "-"
+            Span { start: 32, end: 33, file: None }, // "["
+            Span { start: 33, end: 34, file: None }, // "B"
+            Span { start: 34, end: 35, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -80,7 +88,7 @@ fn test_parse_simple_subtraction() {
 
 #[test]
 fn test_parse_simple_multiplication() {
-    let source = "#define constant RESULT = A * B";
+    let source = "#define constant RESULT = [A] * [B]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -92,13 +100,13 @@ fn test_parse_simple_multiplication() {
     let expected = ConstantDefinition {
         name: "RESULT".to_string(),
         value: ConstVal::Expression(Expression::Binary {
-            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 27, file: None }]) }),
+            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 29, file: None }]) }),
             op: BinaryOp::Mul,
-            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 30, end: 31, file: None }]) }),
+            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 32, end: 35, file: None }]) }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None },
-                Span { start: 28, end: 29, file: None },
+                Span { start: 26, end: 29, file: None },
                 Span { start: 30, end: 31, file: None },
+                Span { start: 32, end: 35, file: None },
             ]),
         }),
         span: AstSpan(vec![
@@ -106,9 +114,13 @@ fn test_parse_simple_multiplication() {
             Span { start: 8, end: 16, file: None },
             Span { start: 17, end: 23, file: None },
             Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 28, end: 29, file: None },
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 28, file: None }, // "A"
+            Span { start: 28, end: 29, file: None }, // "]"
             Span { start: 30, end: 31, file: None },
+            Span { start: 32, end: 33, file: None }, // "["
+            Span { start: 33, end: 34, file: None }, // "B"
+            Span { start: 34, end: 35, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -116,7 +128,7 @@ fn test_parse_simple_multiplication() {
 
 #[test]
 fn test_parse_simple_division() {
-    let source = "#define constant RESULT = A / B";
+    let source = "#define constant RESULT = [A] / [B]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -128,13 +140,13 @@ fn test_parse_simple_division() {
     let expected = ConstantDefinition {
         name: "RESULT".to_string(),
         value: ConstVal::Expression(Expression::Binary {
-            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 27, file: None }]) }),
+            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 29, file: None }]) }),
             op: BinaryOp::Div,
-            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 30, end: 31, file: None }]) }),
+            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 32, end: 35, file: None }]) }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None },
-                Span { start: 28, end: 29, file: None },
+                Span { start: 26, end: 29, file: None },
                 Span { start: 30, end: 31, file: None },
+                Span { start: 32, end: 35, file: None },
             ]),
         }),
         span: AstSpan(vec![
@@ -142,9 +154,13 @@ fn test_parse_simple_division() {
             Span { start: 8, end: 16, file: None },
             Span { start: 17, end: 23, file: None },
             Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 28, end: 29, file: None },
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 28, file: None }, // "A"
+            Span { start: 28, end: 29, file: None }, // "]"
             Span { start: 30, end: 31, file: None },
+            Span { start: 32, end: 33, file: None }, // "["
+            Span { start: 33, end: 34, file: None }, // "B"
+            Span { start: 34, end: 35, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -152,7 +168,7 @@ fn test_parse_simple_division() {
 
 #[test]
 fn test_parse_simple_modulo() {
-    let source = "#define constant RESULT = A % B";
+    let source = "#define constant RESULT = [A] % [B]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -164,13 +180,13 @@ fn test_parse_simple_modulo() {
     let expected = ConstantDefinition {
         name: "RESULT".to_string(),
         value: ConstVal::Expression(Expression::Binary {
-            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 27, file: None }]) }),
+            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 29, file: None }]) }),
             op: BinaryOp::Mod,
-            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 30, end: 31, file: None }]) }),
+            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 32, end: 35, file: None }]) }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None },
-                Span { start: 28, end: 29, file: None },
+                Span { start: 26, end: 29, file: None },
                 Span { start: 30, end: 31, file: None },
+                Span { start: 32, end: 35, file: None },
             ]),
         }),
         span: AstSpan(vec![
@@ -178,9 +194,13 @@ fn test_parse_simple_modulo() {
             Span { start: 8, end: 16, file: None },
             Span { start: 17, end: 23, file: None },
             Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 28, end: 29, file: None },
-            Span { start: 30, end: 31, file: None },
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 28, file: None }, // "A"
+            Span { start: 28, end: 29, file: None }, // "]"
+            Span { start: 30, end: 31, file: None }, // "%"
+            Span { start: 32, end: 33, file: None }, // "["
+            Span { start: 33, end: 34, file: None }, // "B"
+            Span { start: 34, end: 35, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -188,7 +208,7 @@ fn test_parse_simple_modulo() {
 
 #[test]
 fn test_parse_unary_negation() {
-    let source = "#define constant RESULT = -A";
+    let source = "#define constant RESULT = -[A]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -201,10 +221,10 @@ fn test_parse_unary_negation() {
         name: "RESULT".to_string(),
         value: ConstVal::Expression(Expression::Unary {
             op: UnaryOp::Neg,
-            expr: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 27, end: 28, file: None }]) }),
+            expr: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 27, end: 30, file: None }]) }),
             span: AstSpan(vec![
                 Span { start: 26, end: 27, file: None }, // "-"
-                Span { start: 27, end: 28, file: None }, // "A"
+                Span { start: 27, end: 30, file: None }, // "[A]"
             ]),
         }),
         span: AstSpan(vec![
@@ -212,8 +232,10 @@ fn test_parse_unary_negation() {
             Span { start: 8, end: 16, file: None },
             Span { start: 17, end: 23, file: None },
             Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 27, end: 28, file: None },
+            Span { start: 26, end: 27, file: None }, // "-"
+            Span { start: 27, end: 28, file: None }, // "["
+            Span { start: 28, end: 29, file: None }, // "A"
+            Span { start: 29, end: 30, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -223,7 +245,7 @@ fn test_parse_unary_negation() {
 
 #[test]
 fn test_parse_precedence_mul_before_add() {
-    let source = "#define constant RESULT = A + B * C";
+    let source = "#define constant RESULT = [A] + [B] * [C]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -237,42 +259,48 @@ fn test_parse_precedence_mul_before_add() {
     let expected = ConstantDefinition {
         name: "RESULT".to_string(),
         value: ConstVal::Expression(Expression::Binary {
-            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 27, file: None }]) }),
+            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 29, file: None }]) }),
             op: BinaryOp::Add,
             right: Box::new(Expression::Binary {
                 left: Box::new(Expression::Constant {
                     name: "B".to_string(),
-                    span: AstSpan(vec![Span { start: 30, end: 31, file: None }]),
+                    span: AstSpan(vec![Span { start: 32, end: 35, file: None }]),
                 }),
                 op: BinaryOp::Mul,
                 right: Box::new(Expression::Constant {
                     name: "C".to_string(),
-                    span: AstSpan(vec![Span { start: 34, end: 35, file: None }]),
+                    span: AstSpan(vec![Span { start: 38, end: 41, file: None }]),
                 }),
                 span: AstSpan(vec![
-                    Span { start: 30, end: 31, file: None }, // "B"
-                    Span { start: 32, end: 33, file: None }, // "*"
-                    Span { start: 34, end: 35, file: None }, // "C"
+                    Span { start: 32, end: 35, file: None }, // "[B]"
+                    Span { start: 36, end: 37, file: None }, // "*"
+                    Span { start: 38, end: 41, file: None }, // "[C]"
                 ]),
             }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None }, // "A"
-                Span { start: 28, end: 29, file: None }, // "+"
-                Span { start: 30, end: 31, file: None }, // "B"
-                Span { start: 32, end: 33, file: None }, // "*"
-                Span { start: 34, end: 35, file: None }, // "C"
+                Span { start: 26, end: 29, file: None }, // "[A]"
+                Span { start: 30, end: 31, file: None }, // "+"
+                Span { start: 32, end: 35, file: None }, // "[B]"
+                Span { start: 36, end: 37, file: None }, // "*"
+                Span { start: 38, end: 41, file: None }, // "[C]"
             ]),
         }),
         span: AstSpan(vec![
-            Span { start: 0, end: 7, file: None },
-            Span { start: 8, end: 16, file: None },
-            Span { start: 17, end: 23, file: None },
-            Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 28, end: 29, file: None },
-            Span { start: 30, end: 31, file: None },
-            Span { start: 32, end: 33, file: None },
-            Span { start: 34, end: 35, file: None },
+            Span { start: 0, end: 7, file: None },   // "#define"
+            Span { start: 8, end: 16, file: None },  // "constant"
+            Span { start: 17, end: 23, file: None }, // "RESULT"
+            Span { start: 24, end: 25, file: None }, // "="
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 28, file: None }, // "A"
+            Span { start: 28, end: 29, file: None }, // "]"
+            Span { start: 30, end: 31, file: None }, // "+"
+            Span { start: 32, end: 33, file: None }, // "["
+            Span { start: 33, end: 34, file: None }, // "B"
+            Span { start: 34, end: 35, file: None }, // "]"
+            Span { start: 36, end: 37, file: None }, // "*"
+            Span { start: 38, end: 39, file: None }, // "["
+            Span { start: 39, end: 40, file: None }, // "C"
+            Span { start: 40, end: 41, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -280,7 +308,7 @@ fn test_parse_precedence_mul_before_add() {
 
 #[test]
 fn test_parse_precedence_div_before_sub() {
-    let source = "#define constant RESULT = A - B / C";
+    let source = "#define constant RESULT = [A] - [B] / [C]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -294,42 +322,48 @@ fn test_parse_precedence_div_before_sub() {
     let expected = ConstantDefinition {
         name: "RESULT".to_string(),
         value: ConstVal::Expression(Expression::Binary {
-            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 27, file: None }]) }),
+            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 29, file: None }]) }),
             op: BinaryOp::Sub,
             right: Box::new(Expression::Binary {
                 left: Box::new(Expression::Constant {
                     name: "B".to_string(),
-                    span: AstSpan(vec![Span { start: 30, end: 31, file: None }]),
+                    span: AstSpan(vec![Span { start: 32, end: 35, file: None }]),
                 }),
                 op: BinaryOp::Div,
                 right: Box::new(Expression::Constant {
                     name: "C".to_string(),
-                    span: AstSpan(vec![Span { start: 34, end: 35, file: None }]),
+                    span: AstSpan(vec![Span { start: 38, end: 41, file: None }]),
                 }),
                 span: AstSpan(vec![
-                    Span { start: 30, end: 31, file: None },
-                    Span { start: 32, end: 33, file: None },
-                    Span { start: 34, end: 35, file: None },
+                    Span { start: 32, end: 35, file: None }, // "[B]"
+                    Span { start: 36, end: 37, file: None }, // "/"
+                    Span { start: 38, end: 41, file: None }, // "[C]"
                 ]),
             }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None },
-                Span { start: 28, end: 29, file: None },
-                Span { start: 30, end: 31, file: None },
-                Span { start: 32, end: 33, file: None },
-                Span { start: 34, end: 35, file: None },
+                Span { start: 26, end: 29, file: None }, // "[A]"
+                Span { start: 30, end: 31, file: None }, // "-"
+                Span { start: 32, end: 35, file: None }, // "[B]"
+                Span { start: 36, end: 37, file: None }, // "/"
+                Span { start: 38, end: 41, file: None }, // "[C]"
             ]),
         }),
         span: AstSpan(vec![
-            Span { start: 0, end: 7, file: None },
-            Span { start: 8, end: 16, file: None },
-            Span { start: 17, end: 23, file: None },
-            Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 28, end: 29, file: None },
-            Span { start: 30, end: 31, file: None },
-            Span { start: 32, end: 33, file: None },
-            Span { start: 34, end: 35, file: None },
+            Span { start: 0, end: 7, file: None },   // "#define"
+            Span { start: 8, end: 16, file: None },  // "constant"
+            Span { start: 17, end: 23, file: None }, // "RESULT"
+            Span { start: 24, end: 25, file: None }, // "="
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 28, file: None }, // "A"
+            Span { start: 28, end: 29, file: None }, // "]"
+            Span { start: 30, end: 31, file: None }, // "-"
+            Span { start: 32, end: 33, file: None }, // "["
+            Span { start: 33, end: 34, file: None }, // "B"
+            Span { start: 34, end: 35, file: None }, // "]"
+            Span { start: 36, end: 37, file: None }, // "/"
+            Span { start: 38, end: 39, file: None }, // "["
+            Span { start: 39, end: 40, file: None }, // "C"
+            Span { start: 40, end: 41, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -337,7 +371,7 @@ fn test_parse_precedence_div_before_sub() {
 
 #[test]
 fn test_parse_precedence_mod_before_add() {
-    let source = "#define constant RESULT = A + B % C";
+    let source = "#define constant RESULT = [A] + [B] % [C]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -351,42 +385,48 @@ fn test_parse_precedence_mod_before_add() {
     let expected = ConstantDefinition {
         name: "RESULT".to_string(),
         value: ConstVal::Expression(Expression::Binary {
-            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 27, file: None }]) }),
+            left: Box::new(Expression::Constant { name: "A".to_string(), span: AstSpan(vec![Span { start: 26, end: 29, file: None }]) }),
             op: BinaryOp::Add,
             right: Box::new(Expression::Binary {
                 left: Box::new(Expression::Constant {
                     name: "B".to_string(),
-                    span: AstSpan(vec![Span { start: 30, end: 31, file: None }]),
+                    span: AstSpan(vec![Span { start: 32, end: 35, file: None }]),
                 }),
                 op: BinaryOp::Mod,
                 right: Box::new(Expression::Constant {
                     name: "C".to_string(),
-                    span: AstSpan(vec![Span { start: 34, end: 35, file: None }]),
+                    span: AstSpan(vec![Span { start: 38, end: 41, file: None }]),
                 }),
                 span: AstSpan(vec![
-                    Span { start: 30, end: 31, file: None },
-                    Span { start: 32, end: 33, file: None },
-                    Span { start: 34, end: 35, file: None },
+                    Span { start: 32, end: 35, file: None }, // "[B]"
+                    Span { start: 36, end: 37, file: None }, // "%"
+                    Span { start: 38, end: 41, file: None }, // "[C]"
                 ]),
             }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None },
-                Span { start: 28, end: 29, file: None },
-                Span { start: 30, end: 31, file: None },
-                Span { start: 32, end: 33, file: None },
-                Span { start: 34, end: 35, file: None },
+                Span { start: 26, end: 29, file: None }, // "[A]"
+                Span { start: 30, end: 31, file: None }, // "+"
+                Span { start: 32, end: 35, file: None }, // "[B]"
+                Span { start: 36, end: 37, file: None }, // "%"
+                Span { start: 38, end: 41, file: None }, // "[C]"
             ]),
         }),
         span: AstSpan(vec![
-            Span { start: 0, end: 7, file: None },
-            Span { start: 8, end: 16, file: None },
-            Span { start: 17, end: 23, file: None },
-            Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 28, end: 29, file: None },
-            Span { start: 30, end: 31, file: None },
-            Span { start: 32, end: 33, file: None },
-            Span { start: 34, end: 35, file: None },
+            Span { start: 0, end: 7, file: None },   // "#define"
+            Span { start: 8, end: 16, file: None },  // "constant"
+            Span { start: 17, end: 23, file: None }, // "RESULT"
+            Span { start: 24, end: 25, file: None }, // "="
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 28, file: None }, // "A"
+            Span { start: 28, end: 29, file: None }, // "]"
+            Span { start: 30, end: 31, file: None }, // "+"
+            Span { start: 32, end: 33, file: None }, // "["
+            Span { start: 33, end: 34, file: None }, // "B"
+            Span { start: 34, end: 35, file: None }, // "]"
+            Span { start: 36, end: 37, file: None }, // "%"
+            Span { start: 38, end: 39, file: None }, // "["
+            Span { start: 39, end: 40, file: None }, // "C"
+            Span { start: 40, end: 41, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -394,7 +434,7 @@ fn test_parse_precedence_mod_before_add() {
 
 #[test]
 fn test_parse_precedence_same_level_left_assoc() {
-    let source = "#define constant RESULT = A - B + C";
+    let source = "#define constant RESULT = [A] - [B] + [C]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -411,39 +451,45 @@ fn test_parse_precedence_same_level_left_assoc() {
             left: Box::new(Expression::Binary {
                 left: Box::new(Expression::Constant {
                     name: "A".to_string(),
-                    span: AstSpan(vec![Span { start: 26, end: 27, file: None }]),
+                    span: AstSpan(vec![Span { start: 26, end: 29, file: None }]),
                 }),
                 op: BinaryOp::Sub,
                 right: Box::new(Expression::Constant {
                     name: "B".to_string(),
-                    span: AstSpan(vec![Span { start: 30, end: 31, file: None }]),
+                    span: AstSpan(vec![Span { start: 32, end: 35, file: None }]),
                 }),
                 span: AstSpan(vec![
-                    Span { start: 26, end: 27, file: None },
-                    Span { start: 28, end: 29, file: None },
-                    Span { start: 30, end: 31, file: None },
+                    Span { start: 26, end: 29, file: None }, // "[A]"
+                    Span { start: 30, end: 31, file: None }, // "-"
+                    Span { start: 32, end: 35, file: None }, // "[B]"
                 ]),
             }),
             op: BinaryOp::Add,
-            right: Box::new(Expression::Constant { name: "C".to_string(), span: AstSpan(vec![Span { start: 34, end: 35, file: None }]) }),
+            right: Box::new(Expression::Constant { name: "C".to_string(), span: AstSpan(vec![Span { start: 38, end: 41, file: None }]) }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None },
-                Span { start: 28, end: 29, file: None },
-                Span { start: 30, end: 31, file: None },
-                Span { start: 32, end: 33, file: None },
-                Span { start: 34, end: 35, file: None },
+                Span { start: 26, end: 29, file: None }, // "[A]"
+                Span { start: 30, end: 31, file: None }, // "-"
+                Span { start: 32, end: 35, file: None }, // "[B]"
+                Span { start: 36, end: 37, file: None }, // "+"
+                Span { start: 38, end: 41, file: None }, // "[C]"
             ]),
         }),
         span: AstSpan(vec![
-            Span { start: 0, end: 7, file: None },
-            Span { start: 8, end: 16, file: None },
-            Span { start: 17, end: 23, file: None },
-            Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 28, end: 29, file: None },
-            Span { start: 30, end: 31, file: None },
-            Span { start: 32, end: 33, file: None },
-            Span { start: 34, end: 35, file: None },
+            Span { start: 0, end: 7, file: None },   // "#define"
+            Span { start: 8, end: 16, file: None },  // "constant"
+            Span { start: 17, end: 23, file: None }, // "RESULT"
+            Span { start: 24, end: 25, file: None }, // "="
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 28, file: None }, // "A"
+            Span { start: 28, end: 29, file: None }, // "]"
+            Span { start: 30, end: 31, file: None }, // "-"
+            Span { start: 32, end: 33, file: None }, // "["
+            Span { start: 33, end: 34, file: None }, // "B"
+            Span { start: 34, end: 35, file: None }, // "]"
+            Span { start: 36, end: 37, file: None }, // "+"
+            Span { start: 38, end: 39, file: None }, // "["
+            Span { start: 39, end: 40, file: None }, // "C"
+            Span { start: 40, end: 41, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -451,7 +497,7 @@ fn test_parse_precedence_same_level_left_assoc() {
 
 #[test]
 fn test_parse_precedence_mul_div_left_assoc() {
-    let source = "#define constant RESULT = A * B / C";
+    let source = "#define constant RESULT = [A] * [B] / [C]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -468,39 +514,45 @@ fn test_parse_precedence_mul_div_left_assoc() {
             left: Box::new(Expression::Binary {
                 left: Box::new(Expression::Constant {
                     name: "A".to_string(),
-                    span: AstSpan(vec![Span { start: 26, end: 27, file: None }]),
+                    span: AstSpan(vec![Span { start: 26, end: 29, file: None }]),
                 }),
                 op: BinaryOp::Mul,
                 right: Box::new(Expression::Constant {
                     name: "B".to_string(),
-                    span: AstSpan(vec![Span { start: 30, end: 31, file: None }]),
+                    span: AstSpan(vec![Span { start: 32, end: 35, file: None }]),
                 }),
                 span: AstSpan(vec![
-                    Span { start: 26, end: 27, file: None },
-                    Span { start: 28, end: 29, file: None },
-                    Span { start: 30, end: 31, file: None },
+                    Span { start: 26, end: 29, file: None }, // "[A]"
+                    Span { start: 30, end: 31, file: None }, // "*"
+                    Span { start: 32, end: 35, file: None }, // "[B]"
                 ]),
             }),
             op: BinaryOp::Div,
-            right: Box::new(Expression::Constant { name: "C".to_string(), span: AstSpan(vec![Span { start: 34, end: 35, file: None }]) }),
+            right: Box::new(Expression::Constant { name: "C".to_string(), span: AstSpan(vec![Span { start: 38, end: 41, file: None }]) }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None },
-                Span { start: 28, end: 29, file: None },
-                Span { start: 30, end: 31, file: None },
-                Span { start: 32, end: 33, file: None },
-                Span { start: 34, end: 35, file: None },
+                Span { start: 26, end: 29, file: None }, // "[A]"
+                Span { start: 30, end: 31, file: None }, // "*"
+                Span { start: 32, end: 35, file: None }, // "[B]"
+                Span { start: 36, end: 37, file: None }, // "/"
+                Span { start: 38, end: 41, file: None }, // "[C]"
             ]),
         }),
         span: AstSpan(vec![
-            Span { start: 0, end: 7, file: None },
-            Span { start: 8, end: 16, file: None },
-            Span { start: 17, end: 23, file: None },
-            Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 28, end: 29, file: None },
-            Span { start: 30, end: 31, file: None },
-            Span { start: 32, end: 33, file: None },
-            Span { start: 34, end: 35, file: None },
+            Span { start: 0, end: 7, file: None },   // "#define"
+            Span { start: 8, end: 16, file: None },  // "constant"
+            Span { start: 17, end: 23, file: None }, // "RESULT"
+            Span { start: 24, end: 25, file: None }, // "="
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 28, file: None }, // "A"
+            Span { start: 28, end: 29, file: None }, // "]"
+            Span { start: 30, end: 31, file: None }, // "*"
+            Span { start: 32, end: 33, file: None }, // "["
+            Span { start: 33, end: 34, file: None }, // "B"
+            Span { start: 34, end: 35, file: None }, // "]"
+            Span { start: 36, end: 37, file: None }, // "/"
+            Span { start: 38, end: 39, file: None }, // "["
+            Span { start: 39, end: 40, file: None }, // "C"
+            Span { start: 40, end: 41, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -510,7 +562,7 @@ fn test_parse_precedence_mul_div_left_assoc() {
 
 #[test]
 fn test_parse_grouped_expression() {
-    let source = "#define constant RESULT = (A + B) * C";
+    let source = "#define constant RESULT = ([A] + [B]) * [C]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -528,45 +580,51 @@ fn test_parse_grouped_expression() {
                 expr: Box::new(Expression::Binary {
                     left: Box::new(Expression::Constant {
                         name: "A".to_string(),
-                        span: AstSpan(vec![Span { start: 27, end: 28, file: None }]),
+                        span: AstSpan(vec![Span { start: 27, end: 30, file: None }]),
                     }),
                     op: BinaryOp::Add,
                     right: Box::new(Expression::Constant {
                         name: "B".to_string(),
-                        span: AstSpan(vec![Span { start: 31, end: 32, file: None }]),
+                        span: AstSpan(vec![Span { start: 33, end: 36, file: None }]),
                     }),
                     span: AstSpan(vec![
-                        Span { start: 27, end: 28, file: None },
-                        Span { start: 29, end: 30, file: None },
-                        Span { start: 31, end: 32, file: None },
+                        Span { start: 27, end: 30, file: None }, // "[A]"
+                        Span { start: 31, end: 32, file: None }, // "+"
+                        Span { start: 33, end: 36, file: None }, // "[B]"
                     ]),
                 }),
                 span: AstSpan(vec![
                     Span { start: 26, end: 27, file: None }, // "("
-                    Span { start: 32, end: 33, file: None }, // ")"
+                    Span { start: 36, end: 37, file: None }, // ")"
                 ]),
             }),
             op: BinaryOp::Mul,
-            right: Box::new(Expression::Constant { name: "C".to_string(), span: AstSpan(vec![Span { start: 36, end: 37, file: None }]) }),
+            right: Box::new(Expression::Constant { name: "C".to_string(), span: AstSpan(vec![Span { start: 40, end: 43, file: None }]) }),
             span: AstSpan(vec![
                 Span { start: 26, end: 27, file: None }, // "("
-                Span { start: 32, end: 33, file: None }, // ")"
-                Span { start: 34, end: 35, file: None }, // "*"
-                Span { start: 36, end: 37, file: None }, // "C"
+                Span { start: 36, end: 37, file: None }, // ")"
+                Span { start: 38, end: 39, file: None }, // "*"
+                Span { start: 40, end: 43, file: None }, // "[C]"
             ]),
         }),
         span: AstSpan(vec![
-            Span { start: 0, end: 7, file: None },
-            Span { start: 8, end: 16, file: None },
-            Span { start: 17, end: 23, file: None },
-            Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 27, end: 28, file: None },
-            Span { start: 29, end: 30, file: None },
-            Span { start: 31, end: 32, file: None },
-            Span { start: 32, end: 33, file: None },
-            Span { start: 34, end: 35, file: None },
-            Span { start: 36, end: 37, file: None },
+            Span { start: 0, end: 7, file: None },   // "#define"
+            Span { start: 8, end: 16, file: None },  // "constant"
+            Span { start: 17, end: 23, file: None }, // "RESULT"
+            Span { start: 24, end: 25, file: None }, // "="
+            Span { start: 26, end: 27, file: None }, // "("
+            Span { start: 27, end: 28, file: None }, // "["
+            Span { start: 28, end: 29, file: None }, // "A"
+            Span { start: 29, end: 30, file: None }, // "]"
+            Span { start: 31, end: 32, file: None }, // "+"
+            Span { start: 33, end: 34, file: None }, // "["
+            Span { start: 34, end: 35, file: None }, // "B"
+            Span { start: 35, end: 36, file: None }, // "]"
+            Span { start: 36, end: 37, file: None }, // ")"
+            Span { start: 38, end: 39, file: None }, // "*"
+            Span { start: 40, end: 41, file: None }, // "["
+            Span { start: 41, end: 42, file: None }, // "C"
+            Span { start: 42, end: 43, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -574,7 +632,7 @@ fn test_parse_grouped_expression() {
 
 #[test]
 fn test_parse_nested_parentheses() {
-    let source = "#define constant RESULT = ((A + B) * (C + D))";
+    let source = "#define constant RESULT = (([A] + [B]) * ([C] + [D]))";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -605,7 +663,7 @@ fn test_parse_nested_parentheses() {
 
 #[test]
 fn test_parse_deeply_nested_parentheses() {
-    let source = "#define constant RESULT = ((((A))))";
+    let source = "#define constant RESULT = (((([A]))))";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -636,7 +694,7 @@ fn test_parse_deeply_nested_parentheses() {
 
 #[test]
 fn test_parse_negation_of_grouped() {
-    let source = "#define constant RESULT = -(A + B)";
+    let source = "#define constant RESULT = -([A] + [B])";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -653,40 +711,44 @@ fn test_parse_negation_of_grouped() {
                 expr: Box::new(Expression::Binary {
                     left: Box::new(Expression::Constant {
                         name: "A".to_string(),
-                        span: AstSpan(vec![Span { start: 28, end: 29, file: None }]),
+                        span: AstSpan(vec![Span { start: 28, end: 31, file: None }]),
                     }),
                     op: BinaryOp::Add,
                     right: Box::new(Expression::Constant {
                         name: "B".to_string(),
-                        span: AstSpan(vec![Span { start: 32, end: 33, file: None }]),
+                        span: AstSpan(vec![Span { start: 34, end: 37, file: None }]),
                     }),
                     span: AstSpan(vec![
-                        Span { start: 28, end: 29, file: None },
-                        Span { start: 30, end: 31, file: None },
-                        Span { start: 32, end: 33, file: None },
+                        Span { start: 28, end: 31, file: None }, // "[A]"
+                        Span { start: 32, end: 33, file: None }, // "+"
+                        Span { start: 34, end: 37, file: None }, // "[B]"
                     ]),
                 }),
                 span: AstSpan(vec![
                     Span { start: 27, end: 28, file: None }, // "("
-                    Span { start: 33, end: 34, file: None }, // ")"
+                    Span { start: 37, end: 38, file: None }, // ")"
                 ]),
             }),
             span: AstSpan(vec![
                 Span { start: 26, end: 27, file: None }, // "-"
-                Span { start: 33, end: 34, file: None }, // last span from grouped expr
+                Span { start: 37, end: 38, file: None }, // last span from grouped expr
             ]),
         }),
         span: AstSpan(vec![
-            Span { start: 0, end: 7, file: None },
-            Span { start: 8, end: 16, file: None },
-            Span { start: 17, end: 23, file: None },
-            Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 27, end: 28, file: None },
-            Span { start: 28, end: 29, file: None },
-            Span { start: 30, end: 31, file: None },
-            Span { start: 32, end: 33, file: None },
-            Span { start: 33, end: 34, file: None },
+            Span { start: 0, end: 7, file: None },   // "#define"
+            Span { start: 8, end: 16, file: None },  // "constant"
+            Span { start: 17, end: 23, file: None }, // "RESULT"
+            Span { start: 24, end: 25, file: None }, // "="
+            Span { start: 26, end: 27, file: None }, // "-"
+            Span { start: 27, end: 28, file: None }, // "("
+            Span { start: 28, end: 29, file: None }, // "["
+            Span { start: 29, end: 30, file: None }, // "A"
+            Span { start: 30, end: 31, file: None }, // "]"
+            Span { start: 32, end: 33, file: None }, // "+"
+            Span { start: 34, end: 35, file: None }, // "["
+            Span { start: 35, end: 36, file: None }, // "B"
+            Span { start: 36, end: 37, file: None }, // "]"
+            Span { start: 37, end: 38, file: None }, // ")"
         ]),
     };
     assert_eq!(constant, expected);
@@ -719,7 +781,7 @@ fn test_parse_hex_literal_in_expression() {
 
 #[test]
 fn test_parse_constant_reference() {
-    let source = "#define constant RESULT = BASE + OFFSET";
+    let source = "#define constant RESULT = [BASE] + [OFFSET]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -731,16 +793,16 @@ fn test_parse_constant_reference() {
     let expected = ConstantDefinition {
         name: "RESULT".to_string(),
         value: ConstVal::Expression(Expression::Binary {
-            left: Box::new(Expression::Constant { name: "BASE".to_string(), span: AstSpan(vec![Span { start: 26, end: 30, file: None }]) }),
+            left: Box::new(Expression::Constant { name: "BASE".to_string(), span: AstSpan(vec![Span { start: 26, end: 32, file: None }]) }),
             op: BinaryOp::Add,
             right: Box::new(Expression::Constant {
                 name: "OFFSET".to_string(),
-                span: AstSpan(vec![Span { start: 33, end: 39, file: None }]),
+                span: AstSpan(vec![Span { start: 35, end: 43, file: None }]),
             }),
             span: AstSpan(vec![
-                Span { start: 26, end: 30, file: None },
-                Span { start: 31, end: 32, file: None },
-                Span { start: 33, end: 39, file: None },
+                Span { start: 26, end: 32, file: None },
+                Span { start: 33, end: 34, file: None },
+                Span { start: 35, end: 43, file: None },
             ]),
         }),
         span: AstSpan(vec![
@@ -748,9 +810,13 @@ fn test_parse_constant_reference() {
             Span { start: 8, end: 16, file: None },
             Span { start: 17, end: 23, file: None },
             Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 30, file: None },
-            Span { start: 31, end: 32, file: None },
-            Span { start: 33, end: 39, file: None },
+            Span { start: 26, end: 27, file: None }, // "["
+            Span { start: 27, end: 31, file: None }, // "BASE"
+            Span { start: 31, end: 32, file: None }, // "]"
+            Span { start: 33, end: 34, file: None }, // "+"
+            Span { start: 35, end: 36, file: None }, // "["
+            Span { start: 36, end: 42, file: None }, // "OFFSET"
+            Span { start: 42, end: 43, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -758,7 +824,7 @@ fn test_parse_constant_reference() {
 
 #[test]
 fn test_parse_complex_nested() {
-    let source = "#define constant RESULT = (A + B) * C - D / E";
+    let source = "#define constant RESULT = ([A] + [B]) * [C] - [D] / [E]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -800,7 +866,7 @@ fn test_parse_complex_nested() {
 
 #[test]
 fn test_parse_all_operators() {
-    let source = "#define constant RESULT = ((A + B) * C - D) / E % F";
+    let source = "#define constant RESULT = (([A] + [B]) * [C] - [D]) / [E] % [F]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -824,7 +890,7 @@ fn test_parse_all_operators() {
 
 #[test]
 fn test_parse_double_negation() {
-    let source = "#define constant RESULT = --A";
+    let source = "#define constant RESULT = --[A]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -852,7 +918,7 @@ fn test_parse_double_negation() {
 
 #[test]
 fn test_parse_negation_in_expression() {
-    let source = "#define constant RESULT = -A + B";
+    let source = "#define constant RESULT = -[A] + [B]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -868,28 +934,35 @@ fn test_parse_negation_in_expression() {
                 op: UnaryOp::Neg,
                 expr: Box::new(Expression::Constant {
                     name: "A".to_string(),
-                    span: AstSpan(vec![Span { start: 27, end: 28, file: None }]),
+                    span: AstSpan(vec![Span { start: 27, end: 30, file: None }]),
                 }),
-                span: AstSpan(vec![Span { start: 26, end: 27, file: None }, Span { start: 27, end: 28, file: None }]),
+                span: AstSpan(vec![
+                    Span { start: 26, end: 27, file: None }, // "-"
+                    Span { start: 27, end: 30, file: None }, // "[A]"
+                ]),
             }),
             op: BinaryOp::Add,
-            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 31, end: 32, file: None }]) }),
+            right: Box::new(Expression::Constant { name: "B".to_string(), span: AstSpan(vec![Span { start: 33, end: 36, file: None }]) }),
             span: AstSpan(vec![
-                Span { start: 26, end: 27, file: None },
-                Span { start: 27, end: 28, file: None },
-                Span { start: 29, end: 30, file: None },
-                Span { start: 31, end: 32, file: None },
+                Span { start: 26, end: 27, file: None }, // "-"
+                Span { start: 27, end: 30, file: None }, // "[A]"
+                Span { start: 31, end: 32, file: None }, // "+"
+                Span { start: 33, end: 36, file: None }, // "[B]"
             ]),
         }),
         span: AstSpan(vec![
-            Span { start: 0, end: 7, file: None },
-            Span { start: 8, end: 16, file: None },
-            Span { start: 17, end: 23, file: None },
-            Span { start: 24, end: 25, file: None },
-            Span { start: 26, end: 27, file: None },
-            Span { start: 27, end: 28, file: None },
-            Span { start: 29, end: 30, file: None },
-            Span { start: 31, end: 32, file: None },
+            Span { start: 0, end: 7, file: None },   // "#define"
+            Span { start: 8, end: 16, file: None },  // "constant"
+            Span { start: 17, end: 23, file: None }, // "RESULT"
+            Span { start: 24, end: 25, file: None }, // "="
+            Span { start: 26, end: 27, file: None }, // "-"
+            Span { start: 27, end: 28, file: None }, // "["
+            Span { start: 28, end: 29, file: None }, // "A"
+            Span { start: 29, end: 30, file: None }, // "]"
+            Span { start: 31, end: 32, file: None }, // "+"
+            Span { start: 33, end: 34, file: None }, // "["
+            Span { start: 34, end: 35, file: None }, // "B"
+            Span { start: 35, end: 36, file: None }, // "]"
         ]),
     };
     assert_eq!(constant, expected);
@@ -897,7 +970,7 @@ fn test_parse_negation_in_expression() {
 
 #[test]
 fn test_parse_chained_operations() {
-    let source = "#define constant RESULT = A + B + C + D";
+    let source = "#define constant RESULT = [A] + [B] + [C] + [D]";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();

--- a/crates/parser/tests/for_loops.rs
+++ b/crates/parser/tests/for_loops.rs
@@ -84,7 +84,7 @@ fn test_for_loop_with_step() {
 
 #[test]
 fn test_for_loop_with_constants() {
-    let source = "#define macro TEST() = takes(0) returns(0) { for(i in START..END) { } }";
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in [START]..[END]) { } }";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -98,8 +98,8 @@ fn test_for_loop_with_constants() {
     let expected_statement = Statement {
         ty: StatementType::ForLoop {
             variable: "i".to_string(),
-            start: Expression::Constant { name: "START".to_string(), span: AstSpan(vec![Span { start: 54, end: 59, file: None }]) },
-            end: Expression::Constant { name: "END".to_string(), span: AstSpan(vec![Span { start: 61, end: 64, file: None }]) },
+            start: Expression::Constant { name: "START".to_string(), span: AstSpan(vec![Span { start: 54, end: 61, file: None }]) },
+            end: Expression::Constant { name: "END".to_string(), span: AstSpan(vec![Span { start: 63, end: 68, file: None }]) },
             step: None,
             body: vec![],
         },
@@ -108,12 +108,12 @@ fn test_for_loop_with_constants() {
             Span { start: 48, end: 49, file: None }, // "("
             Span { start: 49, end: 50, file: None }, // "i"
             Span { start: 51, end: 53, file: None }, // "in"
-            Span { start: 54, end: 59, file: None }, // "START"
-            Span { start: 59, end: 61, file: None }, // ".."
-            Span { start: 61, end: 64, file: None }, // "END"
-            Span { start: 64, end: 65, file: None }, // ")"
-            Span { start: 66, end: 67, file: None }, // "{"
-            Span { start: 68, end: 69, file: None }, // "}"
+            Span { start: 54, end: 61, file: None }, // "[START]"
+            Span { start: 61, end: 63, file: None }, // ".."
+            Span { start: 63, end: 68, file: None }, // "[END]"
+            Span { start: 68, end: 69, file: None }, // ")"
+            Span { start: 70, end: 71, file: None }, // "{"
+            Span { start: 72, end: 73, file: None }, // "}"
         ]),
     };
 
@@ -123,7 +123,7 @@ fn test_for_loop_with_constants() {
 
 #[test]
 fn test_for_loop_with_arithmetic_bounds() {
-    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..SIZE * 2) { } }";
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..[SIZE] * 2) { } }";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -141,17 +141,17 @@ fn test_for_loop_with_arithmetic_bounds() {
             end: Expression::Binary {
                 left: Box::new(Expression::Constant {
                     name: "SIZE".to_string(),
-                    span: AstSpan(vec![Span { start: 57, end: 61, file: None }]),
+                    span: AstSpan(vec![Span { start: 57, end: 63, file: None }]),
                 }),
                 op: BinaryOp::Mul,
                 right: Box::new(Expression::Literal {
                     value: str_to_bytes32("02"),
-                    span: AstSpan(vec![Span { start: 64, end: 65, file: None }]),
+                    span: AstSpan(vec![Span { start: 66, end: 67, file: None }]),
                 }),
                 span: AstSpan(vec![
-                    Span { start: 57, end: 61, file: None }, // "SIZE"
-                    Span { start: 62, end: 63, file: None }, // "*"
-                    Span { start: 64, end: 65, file: None }, // "2"
+                    Span { start: 57, end: 63, file: None }, // "[SIZE]"
+                    Span { start: 64, end: 65, file: None }, // "*"
+                    Span { start: 66, end: 67, file: None }, // "2"
                 ]),
             },
             step: None,
@@ -164,12 +164,12 @@ fn test_for_loop_with_arithmetic_bounds() {
             Span { start: 51, end: 53, file: None }, // "in"
             Span { start: 54, end: 55, file: None }, // "0"
             Span { start: 55, end: 57, file: None }, // ".."
-            Span { start: 57, end: 61, file: None }, // "SIZE"
-            Span { start: 62, end: 63, file: None }, // "*"
-            Span { start: 64, end: 65, file: None }, // "2"
-            Span { start: 65, end: 66, file: None }, // ")"
-            Span { start: 67, end: 68, file: None }, // "{"
-            Span { start: 69, end: 70, file: None }, // "}"
+            Span { start: 57, end: 63, file: None }, // "[SIZE]"
+            Span { start: 64, end: 65, file: None }, // "*"
+            Span { start: 66, end: 67, file: None }, // "2"
+            Span { start: 67, end: 68, file: None }, // ")"
+            Span { start: 69, end: 70, file: None }, // "{"
+            Span { start: 71, end: 72, file: None }, // "}"
         ]),
     };
 
@@ -341,7 +341,7 @@ fn test_for_loop_with_body_statements() {
 
 #[test]
 fn test_for_loop_with_constant_step() {
-    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..10 step STEP) { } }";
+    let source = "#define macro TEST() = takes(0) returns(0) { for(i in 0..10 step [STEP]) { } }";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -357,7 +357,7 @@ fn test_for_loop_with_constant_step() {
             variable: "i".to_string(),
             start: Expression::Literal { value: str_to_bytes32("00"), span: AstSpan(vec![Span { start: 54, end: 55, file: None }]) },
             end: Expression::Literal { value: str_to_bytes32("10"), span: AstSpan(vec![Span { start: 57, end: 59, file: None }]) },
-            step: Some(Expression::Constant { name: "STEP".to_string(), span: AstSpan(vec![Span { start: 65, end: 69, file: None }]) }),
+            step: Some(Expression::Constant { name: "STEP".to_string(), span: AstSpan(vec![Span { start: 65, end: 71, file: None }]) }),
             body: vec![],
         },
         span: AstSpan(vec![
@@ -369,10 +369,10 @@ fn test_for_loop_with_constant_step() {
             Span { start: 55, end: 57, file: None }, // ".."
             Span { start: 57, end: 59, file: None }, // "10"
             Span { start: 60, end: 64, file: None }, // "step"
-            Span { start: 65, end: 69, file: None }, // "STEP"
-            Span { start: 69, end: 70, file: None }, // ")"
-            Span { start: 71, end: 72, file: None }, // "{"
-            Span { start: 73, end: 74, file: None }, // "}"
+            Span { start: 65, end: 71, file: None }, // "[STEP]"
+            Span { start: 71, end: 72, file: None }, // ")"
+            Span { start: 73, end: 74, file: None }, // "{"
+            Span { start: 75, end: 76, file: None }, // "}"
         ]),
     };
 


### PR DESCRIPTION
- **Breaking**: Bracket notation `[CONSTANT_NAME]` is now required for referencing constants in arithmetic expressions and for-loop bounds (fixes #115).
  - Example: `#define constant RESULT = [A] + [B]` (was: `A + B`)
  - This follow the Huff language convention for constant values using brackets.
  - Applies to: constant definitions with arithmetic expressions, for-loop bounds (`for(i in [START]..[END])`), and for-loop step values.
  - Migration: Update code from `for(i in START..END)` to `for(i in [START]..[END])` and arithmetic expressions from `A + B` to `[A] + [B]`.