### PR TITLE
feat: error for circular constant dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+- Throw error for circular constant dependencies to prevent infinite loops during constant evaluation.
+  - Detects direct cycles (A = B, B = A), indirect cycles (A = B, B = C, C = A), and self-references (A = A + 1).
 
 ## [1.5.0] - 2025-11-02
 - **Breaking**: Bracket notation `[CONSTANT_NAME]` is now required for referencing constants in arithmetic expressions and for-loop bounds (fixes #115).

--- a/crates/core/tests/constants.rs
+++ b/crates/core/tests/constants.rs
@@ -1,6 +1,7 @@
 use huff_neo_codegen::Codegen;
 use huff_neo_lexer::Lexer;
 use huff_neo_parser::Parser;
+use huff_neo_utils::error::CodegenErrorKind;
 use huff_neo_utils::evm_version::EVMVersion;
 use huff_neo_utils::file::full_file_source::FullFileSource;
 use huff_neo_utils::prelude::Token;
@@ -37,4 +38,150 @@ fn test_builtin_rightpad_bytes() {
     let r_bytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None).unwrap();
     // PUSH4 = 0x63, `transfer(address,uint256) signature = 0xa9059cbb
     assert_eq!(&r_bytes, "63a9059cbb");
+}
+
+#[test]
+fn test_direct_circular_constant_dependency() {
+    // Direct circular dependency: A = B, B = A
+    let source = r#"
+        #define constant A = [B]
+        #define constant B = [A]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [A]
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None);
+
+    // Should fail with circular constant dependency error
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err.kind, CodegenErrorKind::CircularConstantDependency(_)));
+}
+
+#[test]
+fn test_indirect_circular_constant_dependency() {
+    // Indirect circular dependency: A = B, B = C, C = A
+    let source = r#"
+        #define constant A = [B]
+        #define constant B = [C]
+        #define constant C = [A]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [A]
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None);
+
+    // Should fail with circular constant dependency error
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err.kind, CodegenErrorKind::CircularConstantDependency(_)));
+}
+
+#[test]
+fn test_self_referencing_constant() {
+    // Self-referencing constant: A = A + 1
+    let source = r#"
+        #define constant A = [A] + 1
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [A]
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None);
+
+    // Should fail with circular constant dependency error
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind, CodegenErrorKind::CircularConstantDependency("A".to_string()));
+}
+
+#[test]
+fn test_valid_constant_references() {
+    // Valid case: constants that reference other constants without cycles
+    let source = r#"
+        #define constant A = 0x01
+        #define constant B = [A] + 0x02
+        #define constant C = [B] * 0x03
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [C]
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None);
+
+    // Should succeed
+    assert!(result.is_ok());
+    let bytecode = result.unwrap();
+    // Should produce bytecode with the calculated value of C = (1 + 2) * 3 = 9
+    assert!(bytecode.contains("6009")); // PUSH1 0x09
+}
+
+#[test]
+fn test_circular_dependency_in_constructor() {
+    // Circular constant dependency used in CONSTRUCTOR
+    let source = r#"
+        #define constant A = [B]
+        #define constant B = [A]
+
+        #define macro CONSTRUCTOR() = takes(0) returns(0) {
+            [A]
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            0x00
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+
+    contract.derive_storage_pointers();
+
+    let result = Codegen::generate_constructor_bytecode(&EVMVersion::default(), &contract, None);
+
+    // Should fail with circular constant dependency error
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err.kind, CodegenErrorKind::CircularConstantDependency(_)));
 }

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -226,6 +226,8 @@ pub enum CodegenErrorKind {
     DuplicateLabelAcrossSiblings(String),
     /// Circular macro invocation detected
     CircularMacroInvocation(String),
+    /// Circular constant dependency detected
+    CircularConstantDependency(String),
     /// Recursion depth limit exceeded
     RecursionDepthExceeded(usize),
     /// Undefined constant in expression
@@ -333,6 +335,9 @@ impl<W: Write> Report<W> for CodegenError {
             }
             CodegenErrorKind::CircularMacroInvocation(macro_name) => {
                 write!(f.out, "Circular macro invocation detected: '{}' is already in the call stack", macro_name)
+            }
+            CodegenErrorKind::CircularConstantDependency(constant_name) => {
+                write!(f.out, "Circular constant dependency detected: '{}' is already being evaluated", constant_name)
             }
             CodegenErrorKind::RecursionDepthExceeded(depth) => {
                 write!(f.out, "Recursion depth limit exceeded: maximum depth of {} reached", depth)
@@ -670,6 +675,14 @@ impl fmt::Display for CompilerError {
                         f,
                         "\nError: Circular macro invocation detected: '{}' is already in the call stack\n{}\n",
                         macro_name,
+                        ce.span.error(None)
+                    )
+                }
+                CodegenErrorKind::CircularConstantDependency(constant_name) => {
+                    write!(
+                        f,
+                        "\nError: Circular constant dependency detected: '{}' is already being evaluated\n{}\n",
+                        constant_name,
                         ce.span.error(None)
                     )
                 }


### PR DESCRIPTION
- Throw error for circular constant dependencies to prevent infinite loops during constant evaluation.
  - Detects direct cycles (A = B, B = A), indirect cycles (A = B, B = C, C = A), and self-references (A = A + 1).