### PR TITLE
fix: allow `__NOOP` as macro argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## Unreleased
 - Throw error for circular constant dependencies to prevent infinite loops during constant evaluation.
   - Detects direct cycles (A = B, B = A), indirect cycles (A = B, B = C, C = A), and self-references (A = A + 1).
+- Fix `__NOOP` not working as a macro argument (fixes #118).
+  - `__NOOP` can now be passed as an argument to macros: `MACRO(__NOOP)`.
+  - Can be used in first-class macro patterns: `<m>(__NOOP)`.
 
 ## [1.5.0] - 2025-11-02
 - **Breaking**: Bracket notation `[CONSTANT_NAME]` is now required for referencing constants in arithmetic expressions and for-loop bounds (fixes #115).

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -254,7 +254,10 @@ impl<'a> Lexer<'a> {
 
                     // Check for __NOOP builtin constant
                     if word == "__NOOP"
-                        && matches!(self.context_stack.top(), &Context::MacroBody | &Context::ForLoopBody | &Context::Constant)
+                        && matches!(
+                            self.context_stack.top(),
+                            &Context::MacroBody | &Context::ForLoopBody | &Context::Constant | &Context::MacroArgs
+                        )
                     {
                         debug!(target: "lexer", "FOUND __NOOP");
                         found_kind = Some(TokenKind::Noop);

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1310,6 +1310,10 @@ impl Parser {
                 self.consume();
                 Ok(MacroArg::Opcode(o))
             }
+            TokenKind::Noop => {
+                self.consume();
+                Ok(MacroArg::Noop)
+            }
             TokenKind::Ident(ident) => {
                 if self.peek().is_some() && self.peek().unwrap().kind == TokenKind::OpenParen {
                     // It's a nested macro call
@@ -1368,7 +1372,7 @@ impl Parser {
             }
             arg => Err(ParserError {
                 kind: ParserErrorKind::InvalidMacroArgs(arg),
-                hint: Some("Expected literal, identifier, opcode, or argument call".to_string()),
+                hint: Some("Expected literal, identifier, opcode, __NOOP, or argument call".to_string()),
                 spans: AstSpan(vec![self.current_token.span.clone()]),
                 cursor: self.cursor,
             }),

--- a/crates/parser/tests/noop.rs
+++ b/crates/parser/tests/noop.rs
@@ -1,5 +1,6 @@
 use huff_neo_lexer::*;
 use huff_neo_parser::*;
+use huff_neo_utils::ast::span::AstSpan;
 use huff_neo_utils::file::full_file_source::FullFileSource;
 use huff_neo_utils::{opcodes::Opcode, prelude::*};
 
@@ -14,9 +15,20 @@ fn test_parses_noop_constant() {
     assert_eq!(parser.current_token.kind, TokenKind::Eof);
 
     let noop_constant = contract.constants.lock().unwrap()[0].clone();
-    assert_eq!(noop_constant.name, "MY_NOOP");
-    assert_eq!(noop_constant.value, ConstVal::Noop);
-    assert_eq!(noop_constant.span.0.len(), 5); // Has 5 spans
+    assert_eq!(
+        noop_constant,
+        ConstantDefinition {
+            name: "MY_NOOP".to_string(),
+            value: ConstVal::Noop,
+            span: AstSpan(vec![
+                Span { start: 0, end: 7, file: None },   // #define
+                Span { start: 8, end: 16, file: None },  // constant
+                Span { start: 17, end: 24, file: None }, // MY_NOOP
+                Span { start: 25, end: 26, file: None }, // =
+                Span { start: 27, end: 33, file: None }  // __NOOP
+            ])
+        }
+    );
 }
 
 #[test]
@@ -144,4 +156,169 @@ fn test_parses_multiple_noops_in_sequence() {
     // All __NOOP instances should be skipped, only 0x42 should remain
     assert_eq!(test_macro.statements.len(), 1);
     assert_eq!(test_macro.statements[0].ty, StatementType::Literal(str_to_bytes32("42")));
+}
+
+#[test]
+fn test_parses_noop_as_macro_argument() {
+    // Test that __NOOP works as a macro argument
+    let source = r#"
+        #define macro MACRO(arg) = takes(0) returns(0) {
+            <arg>
+            0x42
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            MACRO(__NOOP)
+        }
+    "#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+    // Get the MAIN macro
+    let main_macro = contract.macros.iter().find(|m| m.1.name == "MAIN").unwrap().1;
+
+    // Should have one MacroInvocation statement
+    assert_eq!(main_macro.statements.len(), 1);
+
+    // Check that MACRO(__NOOP) is parsed correctly
+    if let StatementType::MacroInvocation(mi) = &main_macro.statements[0].ty {
+        assert_eq!(mi.macro_name, "MACRO");
+        assert_eq!(mi.args.len(), 1);
+
+        // The critical assertion: __NOOP should be parsed as MacroArg::Noop, not MacroArg::Ident
+        assert!(matches!(mi.args[0], MacroArg::Noop));
+
+        // Check the span of the MacroInvocation includes all tokens
+        assert_eq!(
+            mi.span,
+            AstSpan(vec![
+                Span { start: 169, end: 174, file: None }, // MACRO
+                Span { start: 174, end: 175, file: None }, // (
+                Span { start: 175, end: 181, file: None }, // __NOOP
+                Span { start: 181, end: 182, file: None }, // )
+            ])
+        );
+    } else {
+        panic!("Expected MacroInvocation for MACRO");
+    }
+}
+
+#[test]
+fn test_parses_noop_with_other_macro_args() {
+    // Test __NOOP mixed with other types of arguments
+    let source = r#"
+        #define macro MACRO(arg1, arg2, arg3) = takes(0) returns(0) {
+            <arg1>
+            <arg2>
+            <arg3>
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            MACRO(0x01, __NOOP, 0x02)
+        }
+    "#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+    // Get the MAIN macro
+    let main_macro = contract.macros.iter().find(|m| m.1.name == "MAIN").unwrap().1;
+
+    // Should have one MacroInvocation statement
+    assert_eq!(main_macro.statements.len(), 1);
+
+    // Check that MACRO(0x01, __NOOP, 0x02) is parsed correctly
+    if let StatementType::MacroInvocation(mi) = &main_macro.statements[0].ty {
+        assert_eq!(mi.macro_name, "MACRO");
+        assert_eq!(mi.args.len(), 3);
+
+        // First argument should be a literal
+        if let MacroArg::Literal(bytes) = &mi.args[0] {
+            assert_eq!(bytes[31], 0x01);
+        } else {
+            panic!("Expected literal 0x01");
+        }
+
+        // Second argument should be Noop
+        assert!(matches!(mi.args[1], MacroArg::Noop));
+
+        // Third argument should be a literal
+        if let MacroArg::Literal(bytes) = &mi.args[2] {
+            assert_eq!(bytes[31], 0x02);
+        } else {
+            panic!("Expected literal 0x02");
+        }
+
+        // Check the span includes all tokens
+        assert_eq!(
+            mi.span,
+            AstSpan(vec![
+                Span { start: 204, end: 209, file: None }, // MACRO
+                Span { start: 209, end: 210, file: None }, // (
+                Span { start: 210, end: 214, file: None }, // 0x01
+                Span { start: 214, end: 215, file: None }, // ,
+                Span { start: 216, end: 222, file: None }, // __NOOP
+                Span { start: 222, end: 223, file: None }, // ,
+                Span { start: 224, end: 228, file: None }, // 0x02
+                Span { start: 228, end: 229, file: None }, // )
+            ])
+        );
+    } else {
+        panic!("Expected MacroInvocation for MACRO");
+    }
+}
+
+#[test]
+fn test_parses_noop_in_arg_macro_invocation() {
+    // Test __NOOP as an argument to an arg macro invocation <m>(__NOOP)
+    let source = r#"
+        #define macro WRAPPER(m) = takes(0) returns(0) {
+            <m>(__NOOP, 0x01)
+        }
+    "#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+    let wrapper_macro = contract.macros.iter().find(|m| m.1.name == "WRAPPER").unwrap().1;
+
+    // Should have one ArgMacroInvocation statement
+    assert_eq!(wrapper_macro.statements.len(), 1);
+
+    // Check that <m>(__NOOP, 0x01) is parsed correctly
+    if let StatementType::ArgMacroInvocation(parent_macro, arg_name, args) = &wrapper_macro.statements[0].ty {
+        assert_eq!(parent_macro, "WRAPPER");
+        assert_eq!(arg_name, "m");
+        assert_eq!(args.len(), 2);
+
+        // First argument should be Noop
+        assert!(matches!(args[0], MacroArg::Noop));
+
+        // Second argument should be a literal
+        if let MacroArg::Literal(bytes) = &args[1] {
+            assert_eq!(bytes[31], 0x01);
+        } else {
+            panic!("Expected literal 0x01");
+        }
+
+        // Check span of the statement
+        assert_eq!(
+            wrapper_macro.statements[0].span,
+            AstSpan(vec![
+                Span { start: 70, end: 73, file: None }, // <m>
+            ])
+        );
+    } else {
+        panic!("Expected ArgMacroInvocation");
+    }
 }

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -203,6 +203,8 @@ pub enum CodegenErrorKind {
     UsizeConversion(String),
     /// Invalid Arguments
     InvalidArguments(String),
+    /// Invalid Macro Argument Type (e.g., cannot invoke __NOOP as a macro)
+    InvalidMacroArgumentType(String),
     /// Invalid Hex String
     InvalidHex(String),
     /// Invalid Table Statement
@@ -302,6 +304,9 @@ impl<W: Write> Report<W> for CodegenError {
             }
             CodegenErrorKind::InvalidArguments(msg) => {
                 write!(f.out, "Invalid arguments: \"{msg}\"")
+            }
+            CodegenErrorKind::InvalidMacroArgumentType(msg) => {
+                write!(f.out, "Invalid macro argument type: {msg}")
             }
             CodegenErrorKind::InvalidHex(msg) => {
                 write!(f.out, "Invalid hex string: \"{msg}\"")
@@ -639,6 +644,9 @@ impl fmt::Display for CompilerError {
                 }
                 CodegenErrorKind::InvalidArguments(_) => {
                     write!(f, "\nError: Invalid Arguments\n{}\n", ce.span.error(None))
+                }
+                CodegenErrorKind::InvalidMacroArgumentType(msg) => {
+                    write!(f, "\nError: Invalid Macro Argument Type\n{}\n{}\n", msg, ce.span.error(None))
                 }
                 CodegenErrorKind::InvalidHex(_) => {
                     write!(f, "\nError: Invalid Hex\n{}\n", ce.span.error(None))

--- a/spec/grammar/huff-neo.pest
+++ b/spec/grammar/huff-neo.pest
@@ -255,7 +255,7 @@ macro_argument = {
     | invoke_macro           // NESTED_MACRO()
     | value_opcode           // add, mul, etc.
     | ref_constant_bare      // MY_CONST (no brackets!)
-    | special_noop
+    | special_noop           // __NOOP
 }
 
 // MACRO BODY STATEMENTS: What can appear inside macro bodies { ... }
@@ -273,6 +273,7 @@ statement = {
     | ref_argument
     | invoke_macro
     | ref_identifier            // label references
+    | special_noop              // __NOOP
 }
 
 // DECORATOR VALUES: Arguments to test decorators #[calldata(...), value(...)]


### PR DESCRIPTION
- Fix `__NOOP` not working as a macro argument (fixes #118).
  - `__NOOP` can now be passed as an argument to macros: `MACRO(__NOOP)`.
  - Can be used in first-class macro patterns: `<m>(__NOOP)`.