### PR TITLE
feat: add compile-time if/else if/else statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+- Add compile-time if/else if/else statements.
+  - Example: `if ([MODE] == 0x01) { 0xAA } else if ([MODE] == 0x02) { 0xBB } else { 0xCC }`
 
 ## [1.5.1] - 2025-11-04
 - Throw error for circular constant dependencies to prevent infinite loops during constant evaluation.

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -11,6 +11,7 @@
   - [Functions and events](huff-language/functions-and-events.md)
   - [Constants](huff-language/constants.md)
   - [Compile-Time Loops](huff-language/compile-time-loops.md)
+  - [Compile-Time Conditionals](huff-language/compile-time-conditionals.md)
   - [Custom Errors](huff-language/custom-errors.md)
   - [Jump Labels](huff-language/jump-labels.md)
   - [Jump Tables](huff-language/jump-tables.md)

--- a/book/get-started/comparison-to-huff-rs.md
+++ b/book/get-started/comparison-to-huff-rs.md
@@ -136,6 +136,42 @@ Generate repetitive code patterns at compile-time using for loops that expand be
 
 See the [Compile-Time Loops](../huff-language/compile-time-loops.md) documentation for complete details and examples.
 
+### Compile-time if/else statements
+Generate conditional code at compile-time using if/else/else if statements that expand before bytecode generation. Only the matching branch is compiled into the final bytecode.
+
+```javascript
+#define constant MODE = 0x01
+#define constant DEBUG = 0x00
+
+#define macro MAIN() = takes(0) returns(0) {
+    if ([MODE] == 0x01) {
+        // This code is compiled (condition is true)
+        0xAA 0x00 mstore
+    } else if ([MODE] == 0x02) {
+        // Not compiled
+        0xBB 0x00 mstore
+    } else {
+        // Not compiled
+        0xCC 0x00 mstore
+    }
+
+    // Supports logical NOT
+    if (![DEBUG]) {
+        // This code is compiled (DEBUG is 0, !0 = 1)
+        0xFF 0x00 mstore
+    }
+}
+```
+
+Supported features:
+- Comparison operators: `==`, `!=`, `<`, `>`, `<=`, `>=`
+- Logical NOT: `!`
+- Arithmetic expressions: `([A] + [B]) > [C]`
+- Nested if statements
+- If/else if/else chains
+
+See the [Compile-Time Conditionals](../huff-language/compile-time-conditionals.md) documentation for complete details and examples.
+
 ### New test capabilities
 The test module has been refactored to use `anvil` and `forge` features from `foundry` to fork the mainnet. This allows for more advanced testing capabilities.
 

--- a/book/huff-language/compile-time-conditionals.md
+++ b/book/huff-language/compile-time-conditionals.md
@@ -1,0 +1,365 @@
+# Compile-Time Conditionals
+
+Huff Neo supports compile-time `if`, `else if`, and `else` statements that expand during compilation. Conditions are evaluated at compile-time, and only the matching branch is included in the final bytecode.
+
+## Syntax
+
+```javascript
+if (condition) {
+    // statements
+}
+
+if (condition) {
+    // statements
+} else {
+    // statements
+}
+
+if (condition) {
+    // statements
+} else if (condition2) {
+    // statements
+} else {
+    // statements
+}
+```
+
+## Features
+
+- **Compile-time expansion**: Statements are expanded during compilation and don't exist in the final bytecode
+- **Constant expressions**: Conditions must be constant expressions
+- **Comparison operators**: `==`, `!=`, `<`, `>`, `<=`, `>=`
+- **Logical NOT**: `!` operator
+- **Nested conditionals**: If statements can be nested
+
+## Basic Usage
+
+### Simple If
+
+```javascript
+#define constant ENABLED = 0x01
+
+#define macro MAIN() = takes(0) returns(0) {
+    if ([ENABLED]) {
+        0x42 0x00 mstore
+    }
+    // Expands to: 0x42 0x00 mstore
+}
+```
+
+### If/Else
+
+```javascript
+#define constant MODE = 0x00
+
+#define macro MAIN() = takes(0) returns(0) {
+    if ([MODE]) {
+        0xAA
+    } else {
+        0xBB
+    }
+    // Expands to: 0xBB
+}
+```
+
+### If/Else If Chain
+
+```javascript
+#define constant VALUE = 0x02
+
+#define macro MAIN() = takes(0) returns(0) {
+    if ([VALUE] == 0x01) {
+        0x11
+    } else if ([VALUE] == 0x02) {
+        0x22
+    } else {
+        0x33
+    }
+    // Expands to: 0x22
+}
+```
+
+## Comparison Operators
+
+Comparison operators return `1` for true, `0` for false.
+
+### Equality
+
+```javascript
+#define constant A = 0x05
+#define constant B = 0x05
+
+if ([A] == [B]) { }  // true
+if ([A] != [B]) { }  // false
+```
+
+### Relational
+
+```javascript
+#define constant X = 0x0A
+#define constant Y = 0x05
+
+if ([X] > [Y]) { }   // true (10 > 5)
+if ([X] < [Y]) { }   // false
+if ([X] >= [Y]) { }  // true
+if ([X] <= [Y]) { }  // false
+```
+
+## Logical NOT
+
+The `!` operator returns `1` if the operand is zero, `0` otherwise.
+
+```javascript
+#define constant DEBUG = 0x00
+
+if (![DEBUG]) {
+    // Expands (DEBUG is zero, !0 = 1)
+    0xFF
+}
+```
+
+## Arithmetic in Conditions
+
+```javascript
+#define constant A = 0x10
+#define constant B = 0x20
+#define constant THRESHOLD = 0x05
+
+#define macro CHECK() = takes(0) returns(0) {
+    if ([A] + [B] > [THRESHOLD]) {
+        0xFF
+    }
+    // Expands to: 0xFF (0x30 > 0x05)
+}
+```
+
+### With Parentheses
+
+```javascript
+#define constant A = 0x02
+#define constant B = 0x03
+#define constant C = 0x04
+
+if (([A] + [B]) * [C] > 0x10) {
+    // ((2 + 3) * 4) > 16
+    // 20 > 16 = true
+}
+```
+
+## Operator Precedence
+
+Operators follow this precedence (highest to lowest):
+
+1. **Parentheses**: `( )`
+2. **Unary**: `-`, `!`
+3. **Multiplicative**: `*`, `/`, `%`
+4. **Additive**: `+`, `-`
+5. **Comparison**: `==`, `!=`, `<`, `>`, `<=`, `>=`
+
+Example:
+
+```javascript
+if ([A] + [B] * [C] > [D]) {
+    // Evaluated as: (A + (B * C)) > D
+}
+```
+
+## Nested Conditionals
+
+```javascript
+#define constant OUTER = 0x01
+#define constant INNER = 0x00
+
+#define macro NESTED() = takes(0) returns(0) {
+    if ([OUTER]) {
+        if ([INNER]) {
+            0xAA
+        } else {
+            0xBB
+        }
+    } else {
+        0xCC
+    }
+    // Expands to: 0xBB
+}
+```
+
+## Constant References
+
+When referencing constants in conditions, use bracket notation `[CONSTANT_NAME]`:
+
+```javascript
+#define constant FLAG = 0x01
+
+// ✓ Correct
+if ([FLAG]) { }
+if ([FLAG] == 0x01) { }
+
+// ✗ Incorrect
+if (FLAG) { }
+```
+
+This follows the Huff language convention for constant values.
+
+## Use Cases
+
+### Feature Flags
+
+```javascript
+#define constant ENABLE_LOGGING = 0x01
+
+#define macro PROCESS() = takes(0) returns(0) {
+    if ([ENABLE_LOGGING]) {
+        __EVENT_HASH("Processed()")
+        0x00 0x00 log0
+    }
+}
+```
+
+### Configuration-Based Generation
+
+```javascript
+#define constant NETWORK = 0x01  // mainnet=1, testnet=2
+
+#define macro GET_CHAIN_ID() = takes(0) returns(1) {
+    if ([NETWORK] == 0x01) {
+        0x01  // Mainnet chain ID
+    } else if ([NETWORK] == 0x02) {
+        0x05  // Goerli chain ID
+    } else {
+        0x7a69  // Local chain ID
+    }
+}
+```
+
+### Build Variants
+
+```javascript
+#define constant DEBUG = 0x00
+
+#define macro MAIN() = takes(0) returns(0) {
+    if ([DEBUG]) {
+        __EVENT_HASH("Debug:Entry()")
+        0x00 0x00 log0
+    }
+
+    PROCESS()
+
+    if ([DEBUG]) {
+        __EVENT_HASH("Debug:Exit()")
+        0x00 0x00 log0
+    }
+}
+```
+
+## Limitations
+
+### Constant Expressions Only
+
+Conditions must be evaluable at compile-time:
+
+```javascript
+// ✓ Valid
+if ([CONSTANT] > 5) { }
+
+// ✗ Invalid - runtime value
+if (calldataload(0x00) > 5) { }
+```
+
+### Label Scoping
+
+Labels in one branch cannot be referenced from another:
+
+```javascript
+// ✗ Invalid
+if ([FLAG]) {
+    success:
+        0x01
+} else {
+    success jump  // Error: success not visible
+}
+```
+
+### No Side Effects
+
+Conditions are pure expressions:
+
+```javascript
+// ✗ Invalid
+if (some_macro()) { }
+```
+
+## Comparison with Runtime Branching
+
+### Compile-Time (if/else)
+
+- Conditions evaluated during compilation
+- Only matching branch in bytecode
+- No runtime cost
+- Cannot use runtime values
+
+```javascript
+if ([CONSTANT] > 5) { }
+```
+
+### Runtime (jumpi)
+
+- Conditions evaluated during execution
+- All branches in bytecode
+- Runtime gas cost
+- Can use any stack values
+
+```javascript
+dup1 0x05 gt
+success jumpi
+// failure branch
+success:
+// success branch
+```
+
+## Technical Notes
+
+- Conditions are evaluated during the expansion phase before bytecode generation
+- Non-zero values are true, zero is false
+- Conditions use constant folding for evaluation
+- Labels follow normal scoping rules within branches
+
+## Examples
+
+### Multi-Level Configuration
+
+```javascript
+#define constant ENV = 0x01  // 1=prod, 2=staging, 3=dev
+
+#define macro MAIN() = takes(0) returns(0) {
+    if ([ENV] == 0x01) {
+        STRICT_VALIDATE()
+    } else if ([ENV] == 0x02) {
+        MEDIUM_VALIDATE()
+    } else {
+        DEBUG_LOG()
+    }
+    CORE_LOGIC()
+}
+```
+
+### Conditional Loop Unrolling
+
+```javascript
+#define constant SIZE = 0x04
+
+#define macro PROCESS() = takes(0) returns(0) {
+    if ([SIZE] <= 0x04) {
+        // Unroll small loops
+        PROCESS_ITEM(0x00)
+        PROCESS_ITEM(0x01)
+        PROCESS_ITEM(0x02)
+        PROCESS_ITEM(0x03)
+    } else {
+        // Use runtime loop for larger sizes
+        for(i in 0..[SIZE]) {
+            PROCESS_ITEM(<i>)
+        }
+    }
+}
+```

--- a/crates/core/tests/if_else.rs
+++ b/crates/core/tests/if_else.rs
@@ -1,0 +1,626 @@
+mod common;
+
+use common::compile_to_bytecode;
+
+#[test]
+fn test_if_condition_true() {
+    // Test if statement with true condition (non-zero constant)
+    let source = r#"
+        #define constant ENABLED = 0x01
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([ENABLED]) {
+                0x42
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0x42 (then branch is compiled)
+    let expected = "6042";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_condition_false() {
+    // Test if statement with false condition (zero constant)
+    let source = r#"
+        #define constant DISABLED = 0x00
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([DISABLED]) {
+                0x42
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: empty (then branch is not compiled)
+    let expected = "";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_else_true_condition() {
+    // Test if/else with true condition
+    let source = r#"
+        #define constant MODE = 0x01
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([MODE]) {
+                0xAA
+            } else {
+                0xBB
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xAA (then branch only)
+    let expected = "60aa";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_else_false_condition() {
+    // Test if/else with false condition
+    let source = r#"
+        #define constant MODE = 0x00
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([MODE]) {
+                0xAA
+            } else {
+                0xBB
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xBB (else branch only)
+    let expected = "60bb";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_else_if_first_match() {
+    // Test if/else if chain where first condition matches
+    let source = r#"
+        #define constant VALUE = 0x01
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([VALUE] == 0x01) {
+                0x11
+            } else if ([VALUE] == 0x02) {
+                0x22
+            } else {
+                0x33
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0x11 (first condition is true)
+    let expected = "6011";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_else_if_second_match() {
+    // Test if/else if chain where second condition matches
+    let source = r#"
+        #define constant VALUE = 0x02
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([VALUE] == 0x01) {
+                0x11
+            } else if ([VALUE] == 0x02) {
+                0x22
+            } else {
+                0x33
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0x22 (second condition is true)
+    let expected = "6022";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_else_if_else_fallthrough() {
+    // Test if/else if/else where else is taken
+    let source = r#"
+        #define constant VALUE = 0x03
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([VALUE] == 0x01) {
+                0x11
+            } else if ([VALUE] == 0x02) {
+                0x22
+            } else {
+                0x33
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0x33 (else branch is taken)
+    let expected = "6033";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_comparison_equal() {
+    // Test if with == comparison operator
+    let source = r#"
+        #define constant A = 0x05
+        #define constant B = 0x05
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([A] == [B]) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xFF (5 == 5 is true)
+    let expected = "60ff";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_comparison_not_equal() {
+    // Test if with != comparison operator
+    let source = r#"
+        #define constant A = 0x05
+        #define constant B = 0x06
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([A] != [B]) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xFF (5 != 6 is true)
+    let expected = "60ff";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_comparison_less_than() {
+    // Test if with < comparison operator
+    let source = r#"
+        #define constant A = 0x05
+        #define constant B = 0x0A
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([A] < [B]) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xFF (5 < 10 is true)
+    let expected = "60ff";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_comparison_greater_than() {
+    // Test if with > comparison operator
+    let source = r#"
+        #define constant A = 0x0A
+        #define constant B = 0x05
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([A] > [B]) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xFF (10 > 5 is true)
+    let expected = "60ff";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_comparison_less_equal() {
+    // Test if with <= comparison operator
+    let source = r#"
+        #define constant A = 0x05
+        #define constant B = 0x05
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([A] <= [B]) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xFF (5 <= 5 is true)
+    let expected = "60ff";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_comparison_greater_equal() {
+    // Test if with >= comparison operator
+    let source = r#"
+        #define constant A = 0x05
+        #define constant B = 0x05
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([A] >= [B]) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xFF (5 >= 5 is true)
+    let expected = "60ff";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_logical_not_true() {
+    // Test if with logical NOT operator (true case)
+    let source = r#"
+        #define constant FLAG = 0x00
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if (![FLAG]) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xFF (!0 = 1, which is true)
+    let expected = "60ff";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_logical_not_false() {
+    // Test if with logical NOT operator (false case)
+    let source = r#"
+        #define constant FLAG = 0x01
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if (![FLAG]) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: empty (!1 = 0, which is false)
+    let expected = "";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_arithmetic_in_condition() {
+    // Test if with arithmetic expression in condition
+    let source = r#"
+        #define constant A = 0x10
+        #define constant B = 0x20
+        #define constant THRESHOLD = 0x05
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([A] + [B] > [THRESHOLD]) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xFF (0x10 + 0x20 = 0x30, which is > 0x05)
+    let expected = "60ff";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_nested() {
+    // Test nested if statements
+    let source = r#"
+        #define constant OUTER = 0x01
+        #define constant INNER = 0x01
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([OUTER]) {
+                if ([INNER]) {
+                    0xAA
+                } else {
+                    0xBB
+                }
+            } else {
+                0xCC
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xAA (both conditions are true)
+    let expected = "60aa";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_nested_outer_false() {
+    // Test nested if with outer condition false
+    let source = r#"
+        #define constant OUTER = 0x00
+        #define constant INNER = 0x01
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([OUTER]) {
+                if ([INNER]) {
+                    0xAA
+                } else {
+                    0xBB
+                }
+            } else {
+                0xCC
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xCC (outer condition is false)
+    let expected = "60cc";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_nested_inner_false() {
+    // Test nested if with inner condition false
+    let source = r#"
+        #define constant OUTER = 0x01
+        #define constant INNER = 0x00
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([OUTER]) {
+                if ([INNER]) {
+                    0xAA
+                } else {
+                    0xBB
+                }
+            } else {
+                0xCC
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xBB (outer true, inner false)
+    let expected = "60bb";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_with_multiple_statements() {
+    // Test if with multiple statements in body
+    let source = r#"
+        #define constant FLAG = 0x01
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([FLAG]) {
+                0x42
+                0x43
+                add
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0x42 PUSH1 0x43 ADD
+    let expected = "604260 4301";
+    assert_eq!(bytecode.to_lowercase(), expected.replace(" ", "").to_lowercase());
+}
+
+#[test]
+fn test_if_sequential() {
+    // Test two sequential if statements
+    let source = r#"
+        #define constant FLAG_A = 0x01
+        #define constant FLAG_B = 0x01
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([FLAG_A]) {
+                0xAA
+            }
+            if ([FLAG_B]) {
+                0xBB
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xAA PUSH1 0xBB
+    let expected = "60aa60bb";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_empty_body() {
+    // Test if with empty body (should compile to nothing)
+    let source = r#"
+        #define constant FLAG = 0x01
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([FLAG]) {
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: empty (body has no statements)
+    let expected = "";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_complex_condition() {
+    // Test if with complex nested arithmetic and comparison
+    let source = r#"
+        #define constant A = 0x02
+        #define constant B = 0x03
+        #define constant C = 0x04
+        #define constant D = 0x05
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if (([A] + [B]) * [C] > [D]) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xFF ((2 + 3) * 4 = 20, which is > 5)
+    let expected = "60ff";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_literal_condition() {
+    // Test if with literal value as condition
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            if (0x01) {
+                0xAA
+            } else {
+                0xBB
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xAA (0x01 is non-zero, thus true)
+    let expected = "60aa";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_literal_zero_condition() {
+    // Test if with literal zero as condition
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) {
+            if (0x00) {
+                0xAA
+            } else {
+                0xBB
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xBB (0x00 is zero, thus false)
+    let expected = "60bb";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_multiple_else_if() {
+    // Test if with multiple else if clauses
+    let source = r#"
+        #define constant VALUE = 0x03
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([VALUE] == 0x01) {
+                0x11
+            } else if ([VALUE] == 0x02) {
+                0x22
+            } else if ([VALUE] == 0x03) {
+                0x33
+            } else if ([VALUE] == 0x04) {
+                0x44
+            } else {
+                0x55
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0x33 (third condition matches)
+    let expected = "6033";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_with_opcodes_in_body() {
+    // Test if with multiple opcodes in body
+    let source = r#"
+        #define constant FLAG = 0x01
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([FLAG]) {
+                0x00 mstore
+                0x20 0x00 return
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH0 MSTORE PUSH1 0x20 PUSH0 RETURN
+    let expected = "5f5260205ff3";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}
+
+#[test]
+fn test_if_with_constant_arithmetic() {
+    // Test if with constant arithmetic in condition
+    let source = r#"
+        #define constant BASE = 0x0A
+        #define constant OFFSET = 0x05
+
+        #define macro MAIN() = takes(0) returns(0) {
+            if ([BASE] - [OFFSET] == 0x05) {
+                0xFF
+            }
+        }
+    "#;
+
+    let bytecode = compile_to_bytecode(source).unwrap();
+
+    // Expected bytecode: PUSH1 0xFF (10 - 5 = 5, which equals 5)
+    let expected = "60ff";
+    assert_eq!(bytecode.to_lowercase(), expected.to_lowercase());
+}

--- a/crates/lexer/tests/if_else.rs
+++ b/crates/lexer/tests/if_else.rs
@@ -1,0 +1,254 @@
+use huff_neo_lexer::*;
+use huff_neo_utils::prelude::*;
+
+#[test]
+fn parses_if_basic() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(condition) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+
+    // Lex 'if' keyword
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let if_span = Span::new(45..47, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::If, if_span));
+
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // condition (identifier)
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // eof
+
+    // We covered the whole source
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_if_else() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(x) { } else { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    let _ = lexer.next(); // #define
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // macro
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // TEST
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // =
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // takes
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // returns
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // 0
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // if
+    let _ = lexer.next(); // open parenthesis
+    let _ = lexer.next(); // x (identifier)
+    let _ = lexer.next(); // close parenthesis
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+
+    // Lex 'else' keyword
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let else_span = Span::new(55..59, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::Else, else_span));
+
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // {
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // whitespace
+    let _ = lexer.next(); // }
+    let _ = lexer.next(); // eof
+
+    // We covered the whole source
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_comparison_equal_equal() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(a == b) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Skip to the comparison operator (26 tokens before ==)
+    for _ in 0..26 {
+        let _ = lexer.next();
+    }
+
+    // Lex '==' operator
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let eq_span = Span::new(50..52, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::EqualEqual, eq_span));
+
+    // Continue lexing to ensure rest is valid
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_comparison_not_equal() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(a != b) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Skip to the comparison operator (26 tokens before !=)
+    for _ in 0..26 {
+        let _ = lexer.next();
+    }
+
+    // Lex '!=' operator
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let ne_span = Span::new(50..52, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::NotEqual, ne_span));
+
+    // Continue lexing to ensure rest is valid
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_comparison_less_equal() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(a <= b) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Skip to the comparison operator (26 tokens before <=)
+    for _ in 0..26 {
+        let _ = lexer.next();
+    }
+
+    // Lex '<=' operator
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let le_span = Span::new(50..52, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::LessEqual, le_span));
+
+    // Continue lexing to ensure rest is valid
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_comparison_greater_equal() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(a >= b) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Skip to the comparison operator (26 tokens before >=)
+    for _ in 0..26 {
+        let _ = lexer.next();
+    }
+
+    // Lex '>=' operator
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let ge_span = Span::new(50..52, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::GreaterEqual, ge_span));
+
+    // Continue lexing to ensure rest is valid
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_logical_not() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(!flag) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Skip to the logical NOT operator (24 tokens before !)
+    for _ in 0..24 {
+        let _ = lexer.next();
+    }
+
+    // Lex '!' operator
+    let tok = lexer.next();
+    let unwrapped = tok.unwrap().unwrap();
+    let not_span = Span::new(48..49, None);
+    assert_eq!(unwrapped, Token::new(TokenKind::Not, not_span));
+
+    // Continue lexing to ensure rest is valid
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_if_nested() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(x) { if(y) { } } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Just verify it lexes without error
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_if_with_newlines() {
+    let source = r#"#define macro TEST() = takes(0) returns(0) {
+        if(condition) {
+        }
+    }"#;
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Just verify it lexes without error
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}
+
+#[test]
+fn parses_if_tight_spacing() {
+    let source = "#define macro TEST() = takes(0) returns(0) {if(x){}}";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let mut lexer = Lexer::new(flattened_source);
+
+    // Just verify it lexes without error
+    while let Some(Ok(_)) = lexer.next() {}
+    assert!(lexer.eof);
+}

--- a/crates/parser/tests/if_else.rs
+++ b/crates/parser/tests/if_else.rs
@@ -1,0 +1,370 @@
+use huff_neo_lexer::*;
+use huff_neo_parser::*;
+use huff_neo_utils::{file::full_file_source::FullFileSource, prelude::*};
+
+#[test]
+fn test_if_basic_literal_condition() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(0x01) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    let expected_statement = Statement {
+        ty: StatementType::IfStatement {
+            condition: Expression::Literal { value: str_to_bytes32("01"), span: AstSpan(vec![Span { start: 48, end: 52, file: None }]) },
+            then_branch: vec![],
+            else_if_branches: vec![],
+            else_branch: None,
+        },
+        span: AstSpan(vec![
+            Span { start: 45, end: 47, file: None }, // "if"
+            Span { start: 47, end: 48, file: None }, // "("
+            Span { start: 48, end: 52, file: None }, // "0x01"
+            Span { start: 52, end: 53, file: None }, // ")"
+            Span { start: 54, end: 55, file: None }, // "{"
+            Span { start: 56, end: 57, file: None }, // "}"
+        ]),
+    };
+
+    assert_eq!(macro_definition.statements[0], expected_statement);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_else_with_constant_condition() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if([FLAG]) { } else { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    let expected_statement = Statement {
+        ty: StatementType::IfStatement {
+            condition: Expression::Constant { name: "FLAG".to_string(), span: AstSpan(vec![Span { start: 48, end: 54, file: None }]) },
+            then_branch: vec![],
+            else_if_branches: vec![],
+            else_branch: Some(vec![]),
+        },
+        span: AstSpan(vec![
+            Span { start: 45, end: 47, file: None }, // "if"
+            Span { start: 47, end: 48, file: None }, // "("
+            Span { start: 48, end: 54, file: None }, // "[FLAG]"
+            Span { start: 54, end: 55, file: None }, // ")"
+            Span { start: 56, end: 57, file: None }, // "{"
+            Span { start: 58, end: 59, file: None }, // "}"
+            Span { start: 60, end: 64, file: None }, // "else"
+            Span { start: 65, end: 66, file: None }, // "{"
+            Span { start: 67, end: 68, file: None }, // "}"
+        ]),
+    };
+
+    assert_eq!(macro_definition.statements[0], expected_statement);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_with_comparison_equal() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if([A] == [B]) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    let expected_statement = Statement {
+        ty: StatementType::IfStatement {
+            condition: Expression::Binary {
+                left: Box::new(Expression::Constant {
+                    name: "A".to_string(),
+                    span: AstSpan(vec![Span { start: 48, end: 51, file: None }]),
+                }),
+                op: BinaryOp::Eq,
+                right: Box::new(Expression::Constant {
+                    name: "B".to_string(),
+                    span: AstSpan(vec![Span { start: 55, end: 58, file: None }]),
+                }),
+                span: AstSpan(vec![
+                    Span { start: 48, end: 51, file: None }, // "[A]"
+                    Span { start: 52, end: 54, file: None }, // "=="
+                    Span { start: 55, end: 58, file: None }, // "[B]"
+                ]),
+            },
+            then_branch: vec![],
+            else_if_branches: vec![],
+            else_branch: None,
+        },
+        span: AstSpan(vec![
+            Span { start: 45, end: 47, file: None }, // "if"
+            Span { start: 47, end: 48, file: None }, // "("
+            Span { start: 48, end: 51, file: None }, // "[A]"
+            Span { start: 52, end: 54, file: None }, // "=="
+            Span { start: 55, end: 58, file: None }, // "[B]"
+            Span { start: 58, end: 59, file: None }, // ")"
+            Span { start: 60, end: 61, file: None }, // "{"
+            Span { start: 62, end: 63, file: None }, // "}"
+        ]),
+    };
+
+    assert_eq!(macro_definition.statements[0], expected_statement);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_with_comparison_greater_than() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if([X] > [Y]) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Check structure
+    let stmt = &macro_definition.statements[0];
+    match &stmt.ty {
+        StatementType::IfStatement { condition, then_branch, else_if_branches, else_branch } => {
+            match condition {
+                Expression::Binary { op, .. } => {
+                    assert_eq!(*op, BinaryOp::Gt);
+                }
+                _ => panic!("Expected binary expression"),
+            }
+            assert_eq!(then_branch.len(), 0);
+            assert_eq!(else_if_branches.len(), 0);
+            assert!(else_branch.is_none());
+        }
+        _ => panic!("Expected IfStatement"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_with_logical_not() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(![FLAG]) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Check structure
+    let stmt = &macro_definition.statements[0];
+    match &stmt.ty {
+        StatementType::IfStatement { condition, .. } => match condition {
+            Expression::Unary { op, .. } => {
+                assert_eq!(*op, UnaryOp::Not);
+            }
+            _ => panic!("Expected unary expression"),
+        },
+        _ => panic!("Expected IfStatement"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_with_arithmetic_in_condition() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if([A] + [B]) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Check structure
+    let stmt = &macro_definition.statements[0];
+    match &stmt.ty {
+        StatementType::IfStatement { condition, .. } => match condition {
+            Expression::Binary { op, .. } => {
+                assert_eq!(*op, BinaryOp::Add);
+            }
+            _ => panic!("Expected binary expression"),
+        },
+        _ => panic!("Expected IfStatement"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_nested() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if([X]) { if([Y]) { } } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Check structure for nested
+    let outer_stmt = &macro_definition.statements[0];
+    match &outer_stmt.ty {
+        StatementType::IfStatement { condition, then_branch, else_if_branches, else_branch } => {
+            assert!(matches!(condition, Expression::Constant { name, .. } if name == "X"));
+            assert_eq!(then_branch.len(), 1);
+            assert_eq!(else_if_branches.len(), 0);
+            assert!(else_branch.is_none());
+            match &then_branch[0].ty {
+                StatementType::IfStatement { condition: inner_cond, .. } => {
+                    assert!(matches!(inner_cond, Expression::Constant { name, .. } if name == "Y"));
+                }
+                _ => panic!("Expected nested IfStatement"),
+            }
+        }
+        _ => panic!("Expected outer IfStatement"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_with_body_statements() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(1) { 0x00 mstore } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Check structure
+    let stmt = &macro_definition.statements[0];
+    match &stmt.ty {
+        StatementType::IfStatement { then_branch, .. } => {
+            assert_eq!(then_branch.len(), 2);
+            assert!(matches!(then_branch[0].ty, StatementType::Literal(_)));
+            assert!(matches!(then_branch[1].ty, StatementType::Opcode(Opcode::Mstore)));
+        }
+        _ => panic!("Expected IfStatement"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_else_if_chain() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if([A]) { } else if([B]) { } else { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Check structure
+    let stmt = &macro_definition.statements[0];
+    match &stmt.ty {
+        StatementType::IfStatement { condition, then_branch, else_if_branches, else_branch } => {
+            assert!(matches!(condition, Expression::Constant { name, .. } if name == "A"));
+            assert_eq!(then_branch.len(), 0);
+            assert_eq!(else_if_branches.len(), 1);
+            assert!(else_branch.is_some());
+
+            // Check else if
+            let (else_if_cond, else_if_body) = &else_if_branches[0];
+            assert!(matches!(else_if_cond, Expression::Constant { name, .. } if name == "B"));
+            assert_eq!(else_if_body.len(), 0);
+        }
+        _ => panic!("Expected IfStatement"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_multiple_else_if() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if([A]) { } else if([B]) { } else if([C]) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Check structure
+    let stmt = &macro_definition.statements[0];
+    match &stmt.ty {
+        StatementType::IfStatement { else_if_branches, .. } => {
+            assert_eq!(else_if_branches.len(), 2);
+        }
+        _ => panic!("Expected IfStatement"),
+    }
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_sequential() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if([A]) { } if([B]) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    // Should parse as two separate if statements
+    assert_eq!(macro_definition.statements.len(), 2);
+    assert!(matches!(macro_definition.statements[0].ty, StatementType::IfStatement { .. }));
+    assert!(matches!(macro_definition.statements[1].ty, StatementType::IfStatement { .. }));
+
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
+#[test]
+fn test_if_with_complex_condition() {
+    let source = "#define macro TEST() = takes(0) returns(0) { if(([A] + [B]) > ([C] * 2)) { } }";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    let contract = parser.parse().unwrap();
+    let macro_definition = contract.macros.get("TEST").cloned().unwrap();
+
+    assert_eq!(macro_definition.statements.len(), 1);
+
+    // Check structure - just verify it parsed as IfStatement
+    assert!(matches!(macro_definition.statements[0].ty, StatementType::IfStatement { .. }));
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}

--- a/crates/utils/src/token.rs
+++ b/crates/utils/src/token.rs
@@ -98,6 +98,16 @@ pub enum TokenKind {
     Mul,
     /// Modulo
     Mod,
+    /// Equal comparison (==)
+    EqualEqual,
+    /// Not equal comparison (!=)
+    NotEqual,
+    /// Less than or equal (<=)
+    LessEqual,
+    /// Greater than or equal (>=)
+    GreaterEqual,
+    /// Logical NOT (!)
+    Not,
     /// A comma
     Comma,
     /// A Colon
@@ -146,6 +156,10 @@ pub enum TokenKind {
     Step,
     /// ".." range operator
     DoubleDot,
+    /// "if" keyword
+    If,
+    /// "else" keyword
+    Else,
 }
 
 impl TokenKind {
@@ -204,6 +218,11 @@ impl fmt::Display for TokenKind {
             TokenKind::Sub => "-",
             TokenKind::Mul => "*",
             TokenKind::Mod => "%",
+            TokenKind::EqualEqual => "==",
+            TokenKind::NotEqual => "!=",
+            TokenKind::LessEqual => "<=",
+            TokenKind::GreaterEqual => ">=",
+            TokenKind::Not => "!",
             TokenKind::Colon => ":",
             TokenKind::Comma => ",",
             TokenKind::Pound => "#",
@@ -239,6 +258,8 @@ impl fmt::Display for TokenKind {
             TokenKind::In => "in",
             TokenKind::Step => "step",
             TokenKind::DoubleDot => "..",
+            TokenKind::If => "if",
+            TokenKind::Else => "else",
         };
 
         write!(f, "{x}")

--- a/spec/grammar/huff-neo.pest
+++ b/spec/grammar/huff-neo.pest
@@ -157,26 +157,42 @@ constant_definition = { "#" ~ "define" ~ "constant" ~ identifier ~ "=" ~ constan
 // ============================================================================
 
 // Compile-time evaluated expressions with operator precedence
-// Can include: arithmetic, constant references, builtins, literals
-// Examples: 0x42, [BASE] + [OFFSET], 0x100 * 2 - 1, __FUNC_SIG("foo()")
-const_expr = { term ~ ((add_op | sub_op) ~ term)* }
+// Can include: arithmetic, constant references, builtins, literals, comparisons
+// Examples: 0x42, [BASE] + [OFFSET], 0x100 * 2 - 1, __FUNC_SIG("foo()"), [A] == [B], ![FLAG]
+const_expr = { comparison }
 
-// Multiplication, division, modulo (higher precedence)
-term = { factor ~ ((mul_op | div_op | mod_op) ~ factor)* }
+// Comparison operators (lowest precedence)
+// Examples: [A] == [B], [X] > [Y], [VALUE] != 0x00
+comparison = { term ~ ((eq_op | ne_op | le_op | ge_op | lt_op | gt_op) ~ term)* }
 
-// Unary minus and primary expressions
-factor = {
-    unary_minus ~ factor
+// Addition and subtraction
+term = { factor ~ ((add_op | sub_op) ~ factor)* }
+
+// Multiplication, division, modulo
+factor = { unary ~ ((mul_op | div_op | mod_op) ~ unary)* }
+
+// Unary operators (highest precedence): negation and logical NOT
+// Examples: -[VALUE], ![FLAG]
+unary = {
+    unary_minus ~ unary
+    | unary_not ~ unary
     | primary
 }
 
 // Operators
 unary_minus = { "-" }
+unary_not = { "!" }
 add_op = { "+" }
 sub_op = { "-" }
 mul_op = { "*" }
 div_op = { "/" }
 mod_op = { "%" }
+eq_op = { "==" }
+ne_op = { "!=" }
+lt_op = { "<" }
+gt_op = { ">" }
+le_op = { "<=" }
+ge_op = { ">=" }
 
 // Reference to another constant (must use brackets)
 // Example: [MY_CONSTANT]
@@ -263,6 +279,7 @@ macro_argument = {
 // Note: Constants use BRACKETED syntax here: [MY_CONST]
 statement = {
     for_loop
+    | if_statement
     | label_definition
     | value_opcode
     | literal_hex
@@ -507,6 +524,38 @@ for_statement = {
 // Reference to loop variable
 // Example: <i> (where i is the loop variable)
 loop_variable_reference = { "<" ~ identifier ~ ">" }
+
+// ============================================================================
+// IF/ELSE STATEMENTS (compile-time conditional compilation)
+// ============================================================================
+
+// Compile-time if statement (evaluates condition at compile time)
+// Examples:
+//   if ([CONSTANT] > 5) { ... }
+//   if ([A] == [B]) { ... } else { ... }
+//   if (![FLAG]) { ... }
+//   if ([MODE] == 1) { ... } else if ([MODE] == 2) { ... } else { ... }
+//   if (([A] + [B]) * [C] > [D]) { ... }
+if_statement = {
+    "if" ~ "(" ~ const_expr ~ ")" ~ if_body
+    ~ else_if_clause*
+    ~ else_clause?
+}
+
+// Else if clause
+// Example: else if ([X] < 10) { ... }
+else_if_clause = {
+    "else" ~ "if" ~ "(" ~ const_expr ~ ")" ~ if_body
+}
+
+// Else clause
+// Example: else { ... }
+else_clause = {
+    "else" ~ if_body
+}
+
+// If statement body
+if_body = { "{" ~ statement* ~ "}" }
 
 // ============================================================================
 // LITERALS AND IDENTIFIERS


### PR DESCRIPTION
- Add compile-time if/else if/else statements.
  - Example: `if ([MODE] == 0x01) { 0xAA } else if ([MODE] == 0x02) { 0xBB } else { 0xCC }`