### PR TITLE
fix: constant substitution should not fail when referencing builtin fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## Unreleased
 - Add compile-time if/else if/else statements.
   - Example: `if ([MODE] == 0x01) { 0xAA } else if ([MODE] == 0x02) { 0xBB } else { 0xCC }`
+- Fix constant substitution failing when referencing builtin functions (fixes #122).
+  - Example: `#define constant C1 = __RIGHTPAD(0x)` and `#define constant C2 = [C1]` now works correctly.
+  - Applies to all builtin functions: `__FUNC_SIG`, `__EVENT_HASH`, `__RIGHTPAD`, `__LEFTPAD`, `__BYTES`.
 
 ## [1.5.1] - 2025-11-04
 - Throw error for circular constant dependencies to prevent infinite loops during constant evaluation.

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -3,7 +3,7 @@
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]
 
-use crate::irgen::builtin_function::{PadDirection, builtin_bytes, builtin_pad, function_signature};
+use crate::irgen::builtin_function::builtin_pad;
 use alloy_primitives::{U256, hex};
 use huff_neo_utils::ast::huff::*;
 use huff_neo_utils::ast::span::AstSpan;
@@ -429,9 +429,11 @@ impl Codegen {
     /// Generates bytecode for a builtin function call used for constants, code tables, etc.
     /// Returns a PushValue that can be converted to bytecode with or without opcode
     pub fn gen_builtin_bytecode(contract: &Contract, bf: &BuiltinFunctionCall, span: AstSpan) -> Result<PushValue, CodegenError> {
+        use huff_neo_utils::builtin_eval::{PadDirection, eval_builtin_bytes, eval_event_hash, eval_function_signature};
         match bf.kind {
-            BuiltinFunctionKind::FunctionSignature => function_signature(contract, bf),
-            BuiltinFunctionKind::Bytes => builtin_bytes(bf),
+            BuiltinFunctionKind::FunctionSignature => eval_function_signature(contract, bf),
+            BuiltinFunctionKind::Bytes => eval_builtin_bytes(bf),
+            BuiltinFunctionKind::EventHash => eval_event_hash(contract, bf),
             BuiltinFunctionKind::LeftPad => builtin_pad(contract, bf, PadDirection::Left),
             BuiltinFunctionKind::RightPad => builtin_pad(contract, bf, PadDirection::Right),
             _ => Err(CodegenError {

--- a/crates/core/tests/builtin_in_constant_reference.rs
+++ b/crates/core/tests/builtin_in_constant_reference.rs
@@ -1,0 +1,196 @@
+mod common;
+
+#[test]
+fn test_rightpad_in_constant_reference() {
+    let source = r#"
+        #define constant C1 = __RIGHTPAD(0x)
+        #define constant C2 = [C1]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [C2]
+        }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    // __RIGHTPAD(0x) produces 32 zero bytes, optimized to PUSH1 0x00
+    assert_eq!(bytecode, "5f"); // PUSH0 (0x5f) in Shanghai+ or PUSH1 0x00 in earlier versions
+}
+
+#[test]
+fn test_func_sig_in_constant_reference() {
+    let source = r#"
+        #define constant SIG = __FUNC_SIG("transfer(address,uint256)")
+        #define constant SELECTOR = [SIG]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [SELECTOR]
+        }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    // transfer(address,uint256) signature = 0xa9059cbb
+    // PUSH4 = 0x63
+    assert_eq!(bytecode, "63a9059cbb");
+}
+
+#[test]
+fn test_event_hash_in_constant_reference() {
+    let source = r#"
+        #define constant HASH = __EVENT_HASH("Transfer(address,address,uint256)")
+        #define constant EVENT_TOPIC = [HASH]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [EVENT_TOPIC]
+        }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    // Transfer(address,address,uint256) event hash
+    // keccak256("Transfer(address,address,uint256)") = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
+    // PUSH32 = 0x7f
+    assert_eq!(bytecode, "7fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+}
+
+#[test]
+fn test_bytes_in_constant_reference() {
+    let source = r#"
+        #define constant B = __BYTES("hello")
+        #define constant BYTES_VAL = [B]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [BYTES_VAL]
+        }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    // "hello" as bytes, right-padded to 32 bytes: 0x68656c6c6f (followed by zeros)
+    // Since it's only 5 bytes, it will be optimized to PUSH5
+    // PUSH5 = 0x64
+    assert_eq!(bytecode, "6468656c6c6f");
+}
+
+#[test]
+fn test_nested_constant_references_with_builtin() {
+    let source = r#"
+        #define constant C1 = __FUNC_SIG("test()")
+        #define constant C2 = [C1]
+        #define constant C3 = [C2]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [C3]
+        }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    // test() signature = keccak256("test()")[0..4] = 0xf8a8fd6d
+    // PUSH4 = 0x63
+    assert_eq!(bytecode, "63f8a8fd6d");
+}
+
+#[test]
+fn test_builtin_in_arithmetic_expression() {
+    let source = r#"
+        #define constant SIG = __FUNC_SIG("test()")
+        #define constant OFFSET = [SIG] + 1
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [OFFSET]
+        }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    // test() signature = 0xf8a8fd6d = 4171875693
+    // 4171875693 + 1 = 4171875694 = 0xf8a8fd6e
+    // PUSH4 = 0x63
+    assert_eq!(bytecode, "63f8a8fd6e");
+}
+
+#[test]
+fn test_leftpad_in_constant_reference() {
+    let source = r#"
+        #define constant PADDED = __LEFTPAD(0x42)
+        #define constant VAL = [PADDED]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [VAL]
+        }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    // __LEFTPAD(0x42) produces 0x0000...0042 (left-padded to 32 bytes)
+    // This is just 0x42, which gets optimized to PUSH1
+    // PUSH1 = 0x60
+    assert_eq!(bytecode, "6042");
+}
+
+#[test]
+fn test_rightpad_vs_leftpad() {
+    let source_right = r#"
+        #define constant PADDED = __RIGHTPAD(0x42)
+        #define constant VAL = [PADDED]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [VAL]
+        }
+    "#;
+
+    let bytecode_right = common::compile_to_bytecode(source_right).unwrap();
+    // __RIGHTPAD(0x42) produces 0x4200...0000 (right-padded to 32 bytes)
+    // This is 0x42 followed by 31 zero bytes
+    // PUSH32 = 0x7f (full 32 bytes)
+    assert_eq!(bytecode_right, "7f4200000000000000000000000000000000000000000000000000000000000000");
+
+    let source_left = r#"
+        #define constant PADDED = __LEFTPAD(0x42)
+        #define constant VAL = [PADDED]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [VAL]
+        }
+    "#;
+
+    let bytecode_left = common::compile_to_bytecode(source_left).unwrap();
+    // __LEFTPAD(0x42) produces 0x0000...0042 (left-padded to 32 bytes)
+    // Leading zeros are trimmed, so it's just 0x42
+    // PUSH1 = 0x60
+    assert_eq!(bytecode_left, "6042");
+}
+
+#[test]
+fn test_multiple_builtins_in_constants() {
+    let source = r#"
+        #define constant FUNC_SIG = __FUNC_SIG("transfer(address,uint256)")
+        #define constant EVENT_HASH = __EVENT_HASH("Transfer(address,address,uint256)")
+        #define constant SIG_REF = [FUNC_SIG]
+        #define constant HASH_REF = [EVENT_HASH]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [SIG_REF]
+            [HASH_REF]
+        }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    // transfer(address,uint256) = 0xa9059cbb (PUSH4)
+    // Transfer(address,address,uint256) = 0xddf252ad... (PUSH32)
+    assert_eq!(bytecode, "63a9059cbb7fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+}
+
+#[test]
+fn test_error_selector_in_constant_reference() {
+    let source = r#"
+        #define error CustomError(uint256)
+
+        #define constant ERR = __FUNC_SIG(CustomError)
+        #define constant ERR_REF = [ERR]
+
+        #define macro MAIN() = takes(0) returns(0) {
+            [ERR_REF]
+        }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    // CustomError(uint256) selector = keccak256("CustomError(uint256)")[0..4] = 0x110b3655
+    // PUSH4 = 0x63
+    assert_eq!(bytecode, "63110b3655");
+}

--- a/crates/utils/src/builtin_eval.rs
+++ b/crates/utils/src/builtin_eval.rs
@@ -1,0 +1,175 @@
+//! Builtin Function Evaluation
+//!
+//! This module provides compile-time evaluation of Huff builtin functions.
+//! These functions compute constant values that can be used in constant expressions.
+
+use crate::ast::span::AstSpan;
+use crate::error::{CodegenError, CodegenErrorKind};
+use crate::prelude::{Argument, BuiltinFunctionArg, BuiltinFunctionCall, Contract, PushValue};
+use alloy_primitives::{B256, hex, keccak256};
+
+/// Creates a CodegenError for invalid arguments
+fn invalid_arguments_error(msg: impl Into<String>, span: &AstSpan) -> CodegenError {
+    CodegenError { kind: CodegenErrorKind::InvalidArguments(msg.into()), span: span.clone_box(), token: None }
+}
+
+/// Creates a CodegenError for invalid hex strings
+fn invalid_hex_error(hex_str: impl Into<String>, span: &AstSpan) -> CodegenError {
+    CodegenError { kind: CodegenErrorKind::InvalidHex(hex_str.into()), span: span.clone_box(), token: None }
+}
+
+/// Validates that the builtin function call has exactly the expected number of arguments
+fn validate_arg_count(bf: &BuiltinFunctionCall, expected: usize, fn_name: &str) -> Result<(), CodegenError> {
+    if bf.args.len() != expected {
+        return Err(invalid_arguments_error(
+            format!("Incorrect number of arguments passed to {}, should be {}: {}", fn_name, expected, bf.args.len()),
+            &bf.span,
+        ));
+    }
+    Ok(())
+}
+
+/// Extracts a single Argument from the first position of a builtin function call
+fn extract_single_argument<'a>(bf: &'a BuiltinFunctionCall, fn_name: &str) -> Result<&'a Argument, CodegenError> {
+    match bf.args.first() {
+        Some(BuiltinFunctionArg::Argument(arg)) => Ok(arg),
+        _ => Err(invalid_arguments_error(format!("Incorrect arguments type passed to {}", fn_name), &bf.span)),
+    }
+}
+
+/// Formats hex string to have even length
+fn format_even_bytes(hex: String) -> String {
+    if hex.len() % 2 == 1 { format!("0{}", hex) } else { hex }
+}
+
+/// Evaluates __EVENT_HASH builtin function
+pub fn eval_event_hash(contract: &Contract, bf: &BuiltinFunctionCall) -> Result<PushValue, CodegenError> {
+    validate_arg_count(bf, 1, "__EVENT_HASH")?;
+    let first_arg = extract_single_argument(bf, "__EVENT_HASH")?;
+    let hash = if let Some(event) = contract.events.iter().find(|e| first_arg.name.as_ref().unwrap().eq(&e.name)) {
+        event.hash
+    } else if let Some(s) = &first_arg.name {
+        keccak256(s).0
+    } else {
+        return Err(CodegenError {
+            kind: CodegenErrorKind::MissingEventInterface(first_arg.name.as_ref().unwrap().to_string()),
+            span: bf.span.clone_box(),
+            token: None,
+        });
+    };
+    Ok(PushValue::from(hash))
+}
+
+/// Evaluates __FUNC_SIG builtin function
+pub fn eval_function_signature(contract: &Contract, bf: &BuiltinFunctionCall) -> Result<PushValue, CodegenError> {
+    validate_arg_count(bf, 1, "__FUNC_SIG")?;
+    let first_arg = extract_single_argument(bf, "__FUNC_SIG")?;
+    let selector = if let Some(func) = contract.functions.iter().find(|f| first_arg.name.as_ref().unwrap().eq(&f.name)) {
+        func.signature
+    } else if let Some(error) = contract.errors.iter().find(|e| first_arg.name.as_ref().unwrap().eq(&e.name)) {
+        error.selector
+    } else if let Some(s) = &first_arg.name {
+        keccak256(s)[..4].try_into().unwrap()
+    } else {
+        return Err(CodegenError {
+            kind: CodegenErrorKind::MissingFunctionInterface(first_arg.name.as_ref().unwrap().to_string()),
+            span: bf.span.clone_box(),
+            token: None,
+        });
+    };
+
+    // Left-pad the 4-byte selector to 32 bytes for B256
+    let mut bytes = [0u8; 32];
+    bytes[28..32].copy_from_slice(&selector);
+    Ok(PushValue::from(bytes))
+}
+
+/// Evaluates __BYTES builtin function
+pub fn eval_builtin_bytes(bf: &BuiltinFunctionCall) -> Result<PushValue, CodegenError> {
+    validate_arg_count(bf, 1, "__BYTES")?;
+    let first_arg = match bf.args[0] {
+        BuiltinFunctionArg::Argument(ref arg) => arg.name.clone().unwrap_or_default(),
+        _ => {
+            return Err(invalid_arguments_error("Invalid argument type passed to __BYTES", &bf.span));
+        }
+    };
+
+    if first_arg.is_empty() {
+        return Err(invalid_arguments_error("Empty string passed to __BYTES", &bf.span));
+    }
+
+    let bytes = first_arg.as_bytes();
+    if bytes.len() > 32 {
+        return Err(invalid_arguments_error("Encoded bytes length exceeds 32 bytes", &bf.span));
+    }
+
+    let mut bytes_array = [0u8; 32];
+    bytes_array[32 - bytes.len()..].copy_from_slice(bytes);
+    Ok(PushValue::from(bytes_array))
+}
+
+/// Direction for padding operations
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PadDirection {
+    /// Left padding: zeros on the left, data on the right
+    Left,
+    /// Right padding: data on the left, zeros on the right
+    Right,
+}
+
+impl std::fmt::Display for PadDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PadDirection::Left => write!(f, "__LEFTPAD"),
+            PadDirection::Right => write!(f, "__RIGHTPAD"),
+        }
+    }
+}
+
+/// Evaluates __LEFTPAD or __RIGHTPAD builtin function
+///
+/// This is a simplified version that only handles literal arguments and nested builtin calls,
+/// but not constant references. For constant references, the caller should resolve them first.
+pub fn eval_builtin_pad_simple(bf: &BuiltinFunctionCall, direction: PadDirection) -> Result<PushValue, CodegenError> {
+    validate_arg_count(bf, 1, &direction.to_string())?;
+
+    let first_arg = match &bf.args[0] {
+        BuiltinFunctionArg::Argument(arg) => arg.name.clone().unwrap_or_default(),
+        BuiltinFunctionArg::BuiltinFunctionCall(inner_call) => {
+            // Recursively evaluate nested builtin calls
+            let push_value = match inner_call.kind {
+                crate::prelude::BuiltinFunctionKind::FunctionSignature => eval_function_signature(&Contract::default(), inner_call)?,
+                crate::prelude::BuiltinFunctionKind::Bytes => eval_builtin_bytes(inner_call)?,
+                crate::prelude::BuiltinFunctionKind::EventHash => eval_event_hash(&Contract::default(), inner_call)?,
+                _ => {
+                    return Err(invalid_arguments_error(format!("Invalid function call argument type passed to {direction}"), &bf.span));
+                }
+            };
+            push_value.to_hex_trimmed()
+        }
+        _ => {
+            return Err(invalid_arguments_error(format!("Invalid argument type passed to {direction}"), &bf.span));
+        }
+    };
+
+    let hex = format_even_bytes(first_arg);
+
+    // Parse hex string to bytes
+    let hex_bytes = hex::decode(&hex).map_err(|_| invalid_hex_error(&hex, &bf.span))?;
+
+    if hex_bytes.len() > 32 {
+        return Err(invalid_arguments_error("Hex string exceeds 32 bytes", &bf.span));
+    }
+
+    let mut bytes_array = [0u8; 32];
+    if direction == PadDirection::Left {
+        // Left pad: zeros on the left, data on the right
+        let start_idx = 32 - hex_bytes.len();
+        bytes_array[start_idx..].copy_from_slice(&hex_bytes);
+    } else {
+        // Right pad: data on the left, zeros on the right
+        bytes_array[..hex_bytes.len()].copy_from_slice(&hex_bytes);
+    }
+
+    Ok(PushValue::new(B256::from(bytes_array)))
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -51,6 +51,9 @@ pub mod wasm;
 /// EVM Version Module
 pub mod evm_version;
 
+/// Builtin Function Evaluation Module
+pub mod builtin_eval;
+
 /// File operations
 pub mod file;
 


### PR DESCRIPTION
- Fix constant substitution failing when referencing builtin functions (fixes #122).
  - Example: `#define constant C1 = __RIGHTPAD(0x)` and `#define constant C2 = [C1]` now works correctly.
  - Applies to all builtin functions: `__FUNC_SIG`, `__EVENT_HASH`, `__RIGHTPAD`, `__LEFTPAD`, `__BYTES`.