### PR TITLE
feat: support builtin functions as macro arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Allow `for`, `if`, and `else` to be used as label names.
 - Add parser support for `<arg>` in if/for expressions (fixes #129).
   - Example: `if (<MODE> == 0x01) { ... }`
+- Add support for builtin functions as macro arguments (fixes #130).
+  - Builtin functions can now be passed as macro arguments: `__FUNC_SIG`, `__EVENT_HASH`, `__BYTES`, `__RIGHTPAD`.
+  - Example: `MACRO(__FUNC_SIG(transfer))`
 
 ## [1.5.2] - 2025-11-05
 - Add compile-time if/else if/else statements.

--- a/book/huff-language/builtin-functions.md
+++ b/book/huff-language/builtin-functions.md
@@ -88,6 +88,39 @@ Some builtin functions can be combined with other functions. Possible combinatio
 - `__RIGHTPAD(__FUNC_SIG("test(address, uint256)"))`
 - `__RIGHTPAD(__BYTES("hello"))`
 
+## Builtin Functions as Macro Arguments
+
+Builtin functions that can be evaluated at compile-time can be passed as macro arguments. This allows for more flexible and reusable macro definitions.
+
+The following builtin functions support being passed as macro arguments:
+- `__FUNC_SIG` - Function selectors
+- `__EVENT_HASH` - Event hashes
+- `__BYTES` - String bytes
+- `__RIGHTPAD` - Right-padded values
+
+### Example
+```javascript
+#define function transfer(address,uint256) nonpayable returns ()
+
+#define macro PUSH_VALUE(val) = takes(0) returns(1) {
+    <val>
+}
+
+#define macro MAIN() = takes(0) returns(0) {
+    // Pass builtin function call as macro argument
+    PUSH_VALUE(__FUNC_SIG(transfer))
+
+    // Pass padded builtin as argument
+    PUSH_VALUE(__RIGHTPAD(0x1234))
+
+    // Pass bytes as argument
+    PUSH_VALUE(__BYTES("test"))
+
+    pop pop pop
+}
+```
+
+This feature enables creating generic utility macros that work with computed values, improving code reusability and maintainability.
 
 ## Example
 ```javascript

--- a/crates/codegen/src/irgen/builtin_function.rs
+++ b/crates/codegen/src/irgen/builtin_function.rs
@@ -168,12 +168,14 @@ pub fn builtin_function_gen<'a>(
         }
         BuiltinFunctionKind::RightPad => {
             let push_value = builtin_pad(contract, bf, PadDirection::Right)?;
-            let push_bytes = push_value.to_hex_with_opcode(evm_version);
-            *offset += push_bytes.len() / 2;
+            // For padding, always use PUSH32 with full 32 bytes (no optimization)
+            let push_bytes = push_value.to_hex_full_with_opcode();
+            *offset += 33; // PUSH32 opcode (1 byte) + 32 bytes of data
             bytes.push_with_offset(starting_offset, Bytes::Raw(push_bytes));
         }
         BuiltinFunctionKind::LeftPad => {
-            return Err(invalid_arguments_error("LeftPad is not supported in a function or macro", &bf.span));
+            // __LEFTPAD is only available in constant definitions and code tables, not in macro bodies
+            return Err(invalid_arguments_error("__LEFTPAD is only available in constant definitions and code tables", &bf.span));
         }
         BuiltinFunctionKind::DynConstructorArg => {
             validate_arg_count(bf, 2, "__CODECOPY_DYN_ARG")?;

--- a/crates/codegen/src/irgen/statements.rs
+++ b/crates/codegen/src/irgen/statements.rs
@@ -62,6 +62,11 @@ fn evaluate_expression_with_context(
                                 });
                             }
                         }
+                        MacroArg::BuiltinFunctionCall(bf) => {
+                            // Builtin function call - evaluate it
+                            let push_value = Codegen::gen_builtin_bytecode(contract, bf, bf.span.clone())?;
+                            return Ok(push_value.value.0);
+                        }
                         MacroArg::ArgCall(nested_arg) => {
                             // Nested argument reference - recursively resolve
                             return evaluate_expression_with_context(

--- a/crates/core/tests/builtin_as_macro_arg.rs
+++ b/crates/core/tests/builtin_as_macro_arg.rs
@@ -1,0 +1,179 @@
+use huff_neo_codegen::Codegen;
+use huff_neo_lexer::*;
+use huff_neo_parser::Parser;
+use huff_neo_utils::file::full_file_source::FullFileSource;
+use huff_neo_utils::prelude::*;
+
+#[test]
+fn test_builtin_function_as_macro_argument() {
+    // Test that builtin functions can be passed as macro arguments (issue #130)
+    let source = r#"
+        #define function transfer(address,uint256) nonpayable returns ()
+
+        #define macro PUSH_VALUE(val) = takes(0) returns(1) {
+            <val>
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            PUSH_VALUE(__FUNC_SIG(transfer))
+            pop
+        }
+    "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Codegen
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false);
+    assert!(result.is_ok(), "Compilation failed: {:?}", result.err());
+
+    let bytecode = result.unwrap();
+
+    // Verify the bytecode contains the function selector for transfer(address,uint256)
+    // The selector is 0xa9059cbb
+    assert!(bytecode.contains("63a9059cbb"), "Bytecode should contain function selector for transfer: {}", bytecode);
+}
+
+#[test]
+fn test_event_hash_as_macro_argument() {
+    // Test that event hash builtin can be passed as macro argument
+    let source = r#"
+        #define event Transfer(address indexed,address indexed,uint256)
+
+        #define macro USE_HASH(hash) = takes(0) returns(1) {
+            <hash>
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            USE_HASH(__EVENT_HASH(Transfer))
+            pop
+        }
+    "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Codegen
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false);
+    assert!(result.is_ok(), "Compilation failed: {:?}", result.err());
+
+    let bytecode = result.unwrap();
+
+    // Should successfully generate bytecode with event hash
+    assert!(!bytecode.is_empty(), "Bytecode should not be empty");
+}
+
+#[test]
+fn test_nested_builtin_calls_as_macro_arguments() {
+    // Test more complex nesting: passing builtin to a macro that passes it to another macro
+    let source = r#"
+        #define function balanceOf(address) view returns (uint256)
+
+        #define macro INNER(sig) = takes(0) returns(1) {
+            <sig>
+        }
+
+        #define macro OUTER(value) = takes(0) returns(1) {
+            INNER(<value>)
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            OUTER(__FUNC_SIG(balanceOf))
+            pop
+        }
+    "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Codegen
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false);
+    assert!(result.is_ok(), "Compilation failed: {:?}", result.err());
+
+    let bytecode = result.unwrap();
+
+    // Verify the bytecode contains the function selector for balanceOf(address)
+    // The selector is 0x70a08231
+    assert!(bytecode.contains("6370a08231"), "Bytecode should contain function selector for balanceOf: {}", bytecode);
+}
+
+#[test]
+fn test_bytes_builtin_as_macro_argument() {
+    // Test that __BYTES can be passed as macro argument
+    let source = r#"
+        #define macro PUSH_VALUE(val) = takes(0) returns(1) {
+            <val>
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            PUSH_VALUE(__BYTES("test"))
+            pop
+        }
+    "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Codegen
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false);
+    assert!(result.is_ok(), "Compilation failed: {:?}", result.err());
+
+    let bytecode = result.unwrap();
+
+    // Verify the bytecode contains the UTF-8 bytes for "test"
+    // "test" = 0x74657374
+    assert!(bytecode.contains("74657374"), "Bytecode should contain bytes for 'test': {}", bytecode);
+}
+
+#[test]
+fn test_rightpad_builtin_as_macro_argument() {
+    // Test that __RIGHTPAD can be passed as macro argument
+    let source = r#"
+        #define macro PUSH_VALUE(val) = takes(0) returns(1) {
+            <val>
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            PUSH_VALUE(__RIGHTPAD(0x1234))
+            pop
+        }
+    "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Codegen
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false);
+    assert!(result.is_ok(), "Compilation failed: {:?}", result.err());
+
+    let bytecode = result.unwrap();
+
+    // Verify the bytecode contains the right-padded value
+    // Should be padded to 32 bytes: 0x1234...0000
+    assert!(bytecode.contains("1234"), "Bytecode should contain right-padded value: {}", bytecode);
+}

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -321,7 +321,11 @@ impl<'a> Lexer<'a> {
                         kind
                     } else if matches!(
                         self.context_stack.top(),
-                        &Context::MacroBody | &Context::BuiltinFunction | &Context::CodeTableBody | &Context::Constant
+                        &Context::MacroBody
+                            | &Context::BuiltinFunction
+                            | &Context::CodeTableBody
+                            | &Context::Constant
+                            | &Context::MacroArgs
                     ) && BuiltinFunctionKind::try_from(&word).is_ok()
                     {
                         TokenKind::BuiltinFunction(word)

--- a/crates/utils/src/ast/huff.rs
+++ b/crates/utils/src/ast/huff.rs
@@ -899,6 +899,10 @@ pub enum MacroArg {
     ///
     /// Example: `APPLY_OP(add)`, `USE_TWO_OPS(tload, clz)`
     Opcode(Opcode),
+    /// Builtin Function Call Argument
+    ///
+    /// Example: `MACRO(__FUNC_SIG(transfer))`, `MACRO(__EVENT_HASH(Transfer))`
+    BuiltinFunctionCall(BuiltinFunctionCall),
     /// __NOOP builtin constant (generates no bytecode)
     ///
     /// Example: `MACRO(__NOOP)`

--- a/crates/utils/src/push_value.rs
+++ b/crates/utils/src/push_value.rs
@@ -69,6 +69,20 @@ impl PushValue {
     pub fn to_hex_full(&self) -> String {
         hex::encode(self.value.0)
     }
+
+    /// Converts the full 32-byte value to hex string with PUSH32 opcode prefix (0x7f).
+    ///
+    /// Always generates a PUSH32 instruction (33 bytes total: 1 byte opcode + 32 bytes data),
+    /// regardless of leading zeros. This is useful for operations that require exact 32-byte
+    /// values on the stack, such as padding functions.
+    ///
+    /// # Examples
+    /// - Value `0x0000...0001` → `"7f0000000000000000000000000000000000000000000000000000000000000001"`
+    /// - Value `0x0000...1234` → `"7f0000000000000000000000000000000000000000000000000000000000001234"`
+    /// - Value `0xFFFF...FFFF` → `"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"`
+    pub fn to_hex_full_with_opcode(&self) -> String {
+        format!("7f{}", self.to_hex_full())
+    }
 }
 
 /// Convert from a 32-byte array directly to PushValue


### PR DESCRIPTION
- Add support for builtin functions as macro arguments (fixes #130).
  - Builtin functions can now be passed as macro arguments: `__FUNC_SIG`, `__EVENT_HASH`, `__BYTES`, `__RIGHTPAD`.
  - Example: `MACRO(__FUNC_SIG(transfer))`