### PR TITLE
chore: reject macros names that are equal to reserved function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add support for builtin functions as macro arguments (fixes #130).
   - Builtin functions can now be passed as macro arguments: `__FUNC_SIG`, `__EVENT_HASH`, `__BYTES`, `__RIGHTPAD`.
   - Example: `MACRO(__FUNC_SIG(transfer))`
+- Reject macros names that are equal to reserved builtin function names (fixes #131).
 
 ## [1.5.2] - 2025-11-05
 - Add compile-time if/else if/else statements.

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -557,6 +557,18 @@ impl Parser {
         })?;
 
         let macro_name: String = self.match_kind(TokenKind::Ident("MACRO_NAME".to_string()))?.to_string();
+
+        // Check for reserved builtin function names
+        if BuiltinFunctionKind::is_reserved_name(&macro_name) {
+            tracing::error!(target: "parser", "RESERVED MACRO NAME: {}", macro_name);
+            return Err(ParserError {
+                kind: ParserErrorKind::InvalidMacroName,
+                hint: Some(format!("{} is a reserved built-in function name and cannot be used as a macro name.", macro_name)),
+                spans: AstSpan(self.spans.clone()),
+                cursor: self.cursor,
+            });
+        }
+
         tracing::info!(target: "parser", "PARSING MACRO: \"{}\"", macro_name);
 
         let macro_arguments = self.parse_args(true, false, false)?;

--- a/crates/parser/tests/builtin_names.rs
+++ b/crates/parser/tests/builtin_names.rs
@@ -1,0 +1,97 @@
+use huff_neo_lexer::Lexer;
+use huff_neo_parser::*;
+use huff_neo_utils::file::full_file_source::FullFileSource;
+use huff_neo_utils::prelude::*;
+
+#[test]
+fn test_rejects_builtin_function_as_macro_name() {
+    // Test that __FUNC_SIG (and other builtins) cannot be used as macro names
+    let source = "#define macro __FUNC_SIG() = takes(0) returns(0) {}";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let result = parser.parse();
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err.kind, ParserErrorKind::InvalidMacroName));
+    assert!(err.hint.is_some());
+    assert!(err.hint.unwrap().contains("reserved"));
+}
+
+#[test]
+fn test_rejects_multiple_builtin_names_as_macros() {
+    // Test various builtin function names
+    let builtin_names = vec![
+        "__FUNC_SIG",
+        "__EVENT_HASH",
+        "__ERROR",
+        "__tablesize",
+        "__codesize",
+        "__tablestart",
+        "__RIGHTPAD",
+        "__LEFTPAD",
+        "__CODECOPY_DYN_ARG",
+        "__VERBATIM",
+        "__BYTES",
+        "__ASSERT_PC",
+        "__NOOP",
+    ];
+
+    for name in builtin_names {
+        let source = format!("#define macro {}() = takes(0) returns(0) {{}}", name);
+        let flattened_source = FullFileSource { source: &source, file: None, spans: vec![] };
+        let lexer = Lexer::new(flattened_source);
+        let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+        let mut parser = Parser::new(tokens, None);
+        let result = parser.parse();
+
+        assert!(result.is_err(), "Expected error for builtin name: {}, but parsing succeeded", name);
+        let err = result.unwrap_err();
+        assert!(matches!(err.kind, ParserErrorKind::InvalidMacroName), "Expected InvalidMacroName error for {}, got {:?}", name, err.kind);
+    }
+}
+
+#[test]
+fn test_allows_non_builtin_macro_names() {
+    // Test that normal macro names still work
+    let source = "#define macro MY_MACRO() = takes(0) returns(0) {}";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let result = parser.parse();
+
+    assert!(result.is_ok(), "Valid macro name should be accepted");
+}
+
+#[test]
+fn test_rejects_builtin_as_function_macro_name() {
+    // Test that builtin names are also rejected for function macros (fn keyword)
+    let source = "#define fn __FUNC_SIG() = takes(0) returns(0) {}";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let result = parser.parse();
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err.kind, ParserErrorKind::InvalidMacroName));
+}
+
+#[test]
+fn test_rejects_builtin_as_test_macro_name() {
+    // Test that builtin names are also rejected for test macros
+    let source = "#define test __EVENT_HASH() = {}";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let result = parser.parse();
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err.kind, ParserErrorKind::InvalidMacroName));
+}

--- a/crates/utils/src/ast/huff.rs
+++ b/crates/utils/src/ast/huff.rs
@@ -1213,6 +1213,28 @@ impl Display for BuiltinFunctionKind {
     }
 }
 
+impl BuiltinFunctionKind {
+    /// Checks if a string matches any reserved builtin function name
+    pub fn is_reserved_name(name: &str) -> bool {
+        matches!(
+            name,
+            "__tablesize"
+                | "__codesize"
+                | "__tablestart"
+                | "__FUNC_SIG"
+                | "__EVENT_HASH"
+                | "__ERROR"
+                | "__RIGHTPAD"
+                | "__LEFTPAD"
+                | "__CODECOPY_DYN_ARG"
+                | "__VERBATIM"
+                | "__BYTES"
+                | "__ASSERT_PC"
+                | "__NOOP"
+        )
+    }
+}
+
 /// A Statement
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Statement {

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -37,6 +37,8 @@ pub enum ParserErrorKind {
     InvalidConstantValue(TokenKind),
     /// Invalid constant name (reserved name)
     InvalidConstantName,
+    /// Invalid macro name (reserved builtin function name)
+    InvalidMacroName,
     /// Unexpected token in macro body
     InvalidTokenInMacroBody(TokenKind),
     /// Unexpected token in label definition
@@ -487,6 +489,9 @@ impl fmt::Display for CompilerError {
                 }
                 ParserErrorKind::InvalidConstantName => {
                     write!(f, "\nError at token {}: Invalid Constant Name \n{}\n", pe.cursor, pe.spans.error(pe.hint.as_ref()))
+                }
+                ParserErrorKind::InvalidMacroName => {
+                    write!(f, "\nError at token {}: Invalid Macro Name \n{}\n", pe.cursor, pe.spans.error(pe.hint.as_ref()))
                 }
                 ParserErrorKind::InvalidTokenInMacroBody(tmb) => {
                     write!(


### PR DESCRIPTION
- Reject macros names that are equal to reserved builtin function names (fixes #131).