### PR TITLE
fix: nested macro argument resolution with labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   - Builtin functions can now be passed as macro arguments: `__FUNC_SIG`, `__EVENT_HASH`, `__BYTES`, `__RIGHTPAD`.
   - Example: `MACRO(__FUNC_SIG(transfer))`
 - Reject macros names that are equal to reserved builtin function names (fixes #131).
+- Fix stack overflow and argument resolution errors in nested macro invocations with labels (fixes #133).
+  - Example: `M2(M3(<arg>))` followed by a label now compiles without errors.
 
 ## [1.5.2] - 2025-11-05
 - Add compile-time if/else if/else statements.


### PR DESCRIPTION
- Fix stack overflow and argument resolution errors in nested macro invocations with labels (fixes #133).
  - Example: `M2(M3(<arg>))` followed by a label now compiles without errors.