### PR TITLE
fix: macro arg scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Add support for `true` and `false` boolean literals in if conditions and macro arguments.
   - `true` evaluates to `0x01`, `false` evaluates to `0x00`.
   - Example: `if (true) { 0xAA } else { 0xBB }`
+- Fix macro argument scoping bug where parameters leaked across macro boundaries (fixes #139).
+  - Macros can no longer access parameters from parent scopes unless explicitly passed.
+  - Example: If `M1(arg)` calls `M2()` without passing `arg`, then `M2` cannot use `<arg>`.
 
 ## [1.5.3] - 2025-11-06
 - Introducing `--relax-jumps` CLI flag to optimize jump instructions from PUSH2 to PUSH1.

--- a/crates/core/tests/nested_macro_argcalls.rs
+++ b/crates/core/tests/nested_macro_argcalls.rs
@@ -153,19 +153,19 @@ fn test_deeply_nested_argcalls() {
 
 #[test]
 fn test_argcall_scope_chain_traversal() {
-    // Tests that ArgCalls properly traverse scope chain to find definitions
-    // When <arg> is not found in immediate macro, it should bubble up to parent scopes
+    // Tests that ArgCalls properly traverse scope chain when parameters are correctly passed
+    // Each macro receives the parameter and passes it to the next level
     let source = r#"
         #define macro INNER(param) = takes(0) returns(1) {
             <param>
         }
 
-        #define macro MIDDLE() = takes(0) returns(1) {
-            INNER(<outer_param>)  // outer_param not defined in MIDDLE, should bubble to OUTER
+        #define macro MIDDLE(outer_param) = takes(0) returns(1) {
+            INNER(<outer_param>)  // MIDDLE has outer_param and passes it to INNER
         }
 
         #define macro OUTER(outer_param) = takes(0) returns(1) {
-            MIDDLE()
+            MIDDLE(<outer_param>)  // OUTER passes outer_param to MIDDLE
         }
 
         #define macro MAIN() = takes(0) returns(1) {


### PR DESCRIPTION
- Fix macro argument scoping bug where parameters leaked across macro boundaries (fixes #139).
  - Macros can no longer access parameters from parent scopes unless explicitly passed.
  - Example: If `M1(arg)` calls `M2()` without passing `arg`, then `M2` cannot use `<arg>`.