### PR TITLE
feat: introduce `__EMBED_TABLE()` builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   - Fix jump table entries are now correctly updated after each relaxation iteration.
   - Fixes issue where jumps at the PUSH1/PUSH2 boundary (byte 255/256) were not optimized.
   - Use correct PC for `__ASSERT_PC` after jump relaxation.
+- Correctly handle decimal literals in for loop bounds (have been interpreted as hex before).
+  - Example: `for(i in 0..255)` and `for(i in 0..0xff)` are now equivalent.
+- Add `__EMBED_TABLE(TABLE_NAME)` builtin function to embed code tables inline.
+  - Embeds table bytes at the current position instead of at the end of bytecode.
+  - Each table can only be embedded once to avoid ambiguity.
+  - `__tablestart(TABLE)` returns the inline embedding position for embedded tables.
 
 ## [1.5.4] - 2025-11-07
 - Add support for `true` and `false` boolean literals in if conditions and macro arguments.

--- a/crates/codegen/src/irgen/statements.rs
+++ b/crates/codegen/src/irgen/statements.rs
@@ -3,6 +3,7 @@ use huff_neo_utils::bytecode::{BytecodeSegments, JumpPlaceholderData, PushOpcode
 use huff_neo_utils::bytes_util::str_to_bytes32;
 use huff_neo_utils::prelude::*;
 use huff_neo_utils::scope::ScopeManager;
+use std::collections::BTreeMap;
 
 use crate::Codegen;
 use crate::irgen::arg_calls::bubble_arg_call;
@@ -216,6 +217,7 @@ pub fn statement_gen<'a>(
     label_indices: &mut LabelIndices,
     table_instances: &mut Jumps,
     utilized_tables: &mut Vec<TableDefinition>,
+    embedded_tables: &mut BTreeMap<String, usize>,
     circular_codesize_invocations: &mut CircularCodeSizeIndices,
     starting_offset: usize,
     relax_jumps: bool,
@@ -669,6 +671,7 @@ pub fn statement_gen<'a>(
                 offset,
                 table_instances,
                 utilized_tables,
+                embedded_tables,
                 circular_codesize_invocations,
                 starting_offset,
                 &mut bytes,
@@ -772,6 +775,7 @@ pub fn statement_gen<'a>(
                 label_indices,
                 table_instances,
                 utilized_tables,
+                embedded_tables,
                 circular_codesize_invocations,
                 starting_offset,
                 relax_jumps,
@@ -820,6 +824,7 @@ pub fn statement_gen<'a>(
                             label_indices,
                             table_instances,
                             utilized_tables,
+                            embedded_tables,
                             circular_codesize_invocations,
                             starting_offset,
                             relax_jumps,
@@ -944,6 +949,7 @@ pub fn statement_gen<'a>(
                                 label_indices,
                                 table_instances,
                                 utilized_tables,
+                                embedded_tables,
                                 circular_codesize_invocations,
                                 starting_offset,
                                 relax_jumps,

--- a/crates/core/tests/embed_table.rs
+++ b/crates/core/tests/embed_table.rs
@@ -1,0 +1,257 @@
+use huff_neo_codegen::Codegen;
+use huff_neo_lexer::Lexer;
+use huff_neo_parser::Parser;
+use huff_neo_utils::error::CodegenErrorKind;
+use huff_neo_utils::evm_version::EVMVersion;
+use huff_neo_utils::file::full_file_source::FullFileSource;
+use huff_neo_utils::prelude::Token;
+
+#[test]
+fn test_embed_table_basic() {
+    let source: &str = r#"
+        #define table CODE_TABLE {
+            0x1234
+            0xDEADBEEF
+        }
+
+        #define macro MAIN() = takes(0) returns (0) {
+            __EMBED_TABLE(CODE_TABLE)
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let mbytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false).unwrap();
+
+    // Table should be embedded inline, not at the end
+    // Expected: just the table bytes directly
+    assert_eq!(mbytes, "1234deadbeef");
+}
+
+#[test]
+fn test_embed_table_with_tablestart() {
+    let source: &str = r#"
+        #define table CODE_TABLE {
+            0x1234
+            0xDEADBEEF
+        }
+
+        #define macro MAIN() = takes(0) returns (0) {
+            __tablestart(CODE_TABLE)  // Should return offset 0x0003 (after PUSH2)
+            __EMBED_TABLE(CODE_TABLE)
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let mbytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false).unwrap();
+
+    // Note: __tablestart is called before __EMBED_TABLE, so it uses a placeholder
+    // The placeholder is PUSH2 by default (61 0003 where 0003 is filled)
+    // 61 = PUSH2, 0003 = offset 3 (where table starts after PUSH2), then the table bytes
+    assert_eq!(mbytes, "610003 1234deadbeef".replace(" ", ""));
+}
+
+#[test]
+fn test_embed_table_not_at_end() {
+    let source: &str = r#"
+        #define table CODE_TABLE {
+            0xABCD
+        }
+
+        #define macro MAIN() = takes(0) returns (0) {
+            __EMBED_TABLE(CODE_TABLE)
+            0x42            // PUSH1 0x42
+            0x01            // PUSH1 0x01
+            mstore          // MSTORE
+            stop
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let mbytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false).unwrap();
+
+    // Table embedded inline, followed by PUSH1, PUSH1, MSTORE, STOP
+    // abcd = table (2 bytes)
+    // 6042 = PUSH1 0x42 (2 bytes)
+    // 6001 = PUSH1 0x01 (2 bytes)
+    // 52 = MSTORE (1 byte)
+    // 00 = STOP (1 byte)
+    // Total: 8 bytes (no table duplication at end)
+    assert_eq!(mbytes, "abcd604260015200");
+}
+
+#[test]
+fn test_embed_table_with_func_sig() {
+    let source: &str = r#"
+        #define table CODE_TABLE {
+            __FUNC_SIG("transfer(address,uint256)")
+            0xDEADBEEF
+        }
+
+        #define macro MAIN() = takes(0) returns (0) {
+            __EMBED_TABLE(CODE_TABLE)
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let mbytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false).unwrap();
+
+    // a9059cbb = transfer(address,uint256) selector
+    assert_eq!(mbytes, "a9059cbb deadbeef".replace(" ", ""));
+}
+
+#[test]
+fn test_embed_table_with_operations_before_and_after() {
+    let source: &str = r#"
+        #define table CODE_TABLE {
+            0x1234
+        }
+
+        #define macro MAIN() = takes(0) returns (0) {
+            0x42            // PUSH1 0x42
+            __EMBED_TABLE(CODE_TABLE)
+            0x01            // PUSH1 0x01
+            mstore          // MSTORE
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let mbytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false).unwrap();
+
+    // 6042 = PUSH1 0x42 (2 bytes)
+    // 1234 = table (2 bytes)
+    // 6001 = PUSH1 0x01 (2 bytes)
+    // 52 = MSTORE (1 byte)
+    // Total: 7 bytes
+    assert_eq!(mbytes, "6042 1234 6001 52".replace(" ", ""));
+}
+
+#[test]
+fn test_embed_table_with_tablestart_and_surrounding_ops() {
+    let source: &str = r#"
+        #define table CODE_TABLE {
+            0xABCD
+        }
+
+        #define macro MAIN() = takes(0) returns (0) {
+            0x42            // PUSH1 0x42 (2 bytes)
+            __tablestart(CODE_TABLE)  // Should return 0x0005 (2 + 3 for PUSH2)
+            __EMBED_TABLE(CODE_TABLE)
+            0x01            // PUSH1 0x01
+            stop
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let mbytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false).unwrap();
+
+    // 6042 = PUSH1 0x42 (2 bytes)
+    // 610005 = PUSH2 0x0005 (3 bytes) - offset where table starts
+    // abcd = table (2 bytes) - at offset 0x0005
+    // 6001 = PUSH1 0x01 (2 bytes)
+    // 00 = STOP (1 byte)
+    // Total: 10 bytes
+    assert_eq!(mbytes, "6042 610005 abcd 6001 00".replace(" ", ""));
+}
+
+#[test]
+fn test_multiple_embedded_tables() {
+    let source: &str = r#"
+        #define table TABLE_A {
+            0x1111
+        }
+
+        #define table TABLE_B {
+            0x2222
+        }
+
+        #define macro MAIN() = takes(0) returns (0) {
+            __tablestart(TABLE_A)   // Should be 0x0003
+            __tablestart(TABLE_B)   // Should be 0x0008 (3 + 2 table_a + 3)
+            __EMBED_TABLE(TABLE_A)  // at 0x0006
+            __EMBED_TABLE(TABLE_B)  // at 0x0008
+            stop
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let mbytes = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false).unwrap();
+
+    // 610006 = PUSH2 0x0006 (3 bytes) - offset where TABLE_A starts
+    // 610008 = PUSH2 0x0008 (3 bytes) - offset where TABLE_B starts
+    // 1111 = TABLE_A (2 bytes) - at offset 0x0006
+    // 2222 = TABLE_B (2 bytes) - at offset 0x0008
+    // 00 = STOP (1 byte)
+    // Total: 11 bytes
+    assert_eq!(mbytes, "610006 610008 1111 2222 00".replace(" ", ""));
+}
+
+#[test]
+fn test_embed_table_duplicate_embedding_fails() {
+    let source: &str = r#"
+        #define table CODE_TABLE {
+            0xABCD
+        }
+
+        #define macro MAIN() = takes(0) returns (0) {
+            __EMBED_TABLE(CODE_TABLE)
+            __EMBED_TABLE(CODE_TABLE)  // Second embedding should fail
+            stop
+        }
+    "#;
+
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let result = Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false);
+
+    // Should return an error because CODE_TABLE is embedded twice
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind, CodegenErrorKind::DuplicateTableEmbedding("CODE_TABLE".to_string()));
+}

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -2178,9 +2178,10 @@ impl Parser {
             }
             TokenKind::Num(n) => {
                 // Handle numeric literals (used in for loops)
+                // Convert decimal to hex string before passing to str_to_bytes32
                 let span = AstSpan(vec![self.current_token.span.clone()]);
                 self.consume();
-                let value = str_to_bytes32(&format!("{}", n));
+                let value = str_to_bytes32(&format!("{:x}", n));
                 Ok(Expression::Literal { value, span })
             }
             TokenKind::OpenParen => {

--- a/crates/parser/tests/for_loops.rs
+++ b/crates/parser/tests/for_loops.rs
@@ -58,7 +58,7 @@ fn test_for_loop_with_step() {
         ty: StatementType::ForLoop {
             variable: "i".to_string(),
             start: Expression::Literal { value: str_to_bytes32("00"), span: AstSpan(vec![Span { start: 54, end: 55, file: None }]) },
-            end: Expression::Literal { value: str_to_bytes32("10"), span: AstSpan(vec![Span { start: 57, end: 59, file: None }]) },
+            end: Expression::Literal { value: str_to_bytes32("0a"), span: AstSpan(vec![Span { start: 57, end: 59, file: None }]) },
             step: Some(Expression::Literal { value: str_to_bytes32("02"), span: AstSpan(vec![Span { start: 65, end: 66, file: None }]) }),
             body: vec![],
         },
@@ -356,7 +356,7 @@ fn test_for_loop_with_constant_step() {
         ty: StatementType::ForLoop {
             variable: "i".to_string(),
             start: Expression::Literal { value: str_to_bytes32("00"), span: AstSpan(vec![Span { start: 54, end: 55, file: None }]) },
-            end: Expression::Literal { value: str_to_bytes32("10"), span: AstSpan(vec![Span { start: 57, end: 59, file: None }]) },
+            end: Expression::Literal { value: str_to_bytes32("0a"), span: AstSpan(vec![Span { start: 57, end: 59, file: None }]) },
             step: Some(Expression::Constant { name: "STEP".to_string(), span: AstSpan(vec![Span { start: 65, end: 71, file: None }]) }),
             body: vec![],
         },
@@ -503,7 +503,7 @@ fn test_for_loop_with_arg_in_step() {
         ty: StatementType::ForLoop {
             variable: "i".to_string(),
             start: Expression::Literal { value: str_to_bytes32("00"), span: AstSpan(vec![Span { start: 63, end: 64, file: None }]) },
-            end: Expression::Literal { value: str_to_bytes32("10"), span: AstSpan(vec![Span { start: 66, end: 68, file: None }]) },
+            end: Expression::Literal { value: str_to_bytes32("0a"), span: AstSpan(vec![Span { start: 66, end: 68, file: None }]) },
             step: Some(Expression::ArgCall {
                 macro_name: String::new(),
                 name: "step_size".to_string(),

--- a/crates/utils/src/ast/huff.rs
+++ b/crates/utils/src/ast/huff.rs
@@ -1130,6 +1130,8 @@ pub enum BuiltinFunctionKind {
     Codesize,
     /// Table start function
     Tablestart,
+    /// Embed table function
+    EmbedTable,
     /// Function signature function
     FunctionSignature,
     /// Event hash function
@@ -1156,6 +1158,7 @@ impl From<String> for BuiltinFunctionKind {
             "__tablesize" => BuiltinFunctionKind::Tablesize,
             "__codesize" => BuiltinFunctionKind::Codesize,
             "__tablestart" => BuiltinFunctionKind::Tablestart,
+            "__EMBED_TABLE" => BuiltinFunctionKind::EmbedTable,
             "__FUNC_SIG" => BuiltinFunctionKind::FunctionSignature,
             "__EVENT_HASH" => BuiltinFunctionKind::EventHash,
             "__ERROR" => BuiltinFunctionKind::Error,
@@ -1180,6 +1183,7 @@ impl TryFrom<&String> for BuiltinFunctionKind {
             "__tablesize" => Ok(BuiltinFunctionKind::Tablesize),
             "__codesize" => Ok(BuiltinFunctionKind::Codesize),
             "__tablestart" => Ok(BuiltinFunctionKind::Tablestart),
+            "__EMBED_TABLE" => Ok(BuiltinFunctionKind::EmbedTable),
             "__FUNC_SIG" => Ok(BuiltinFunctionKind::FunctionSignature),
             "__EVENT_HASH" => Ok(BuiltinFunctionKind::EventHash),
             "__ERROR" => Ok(BuiltinFunctionKind::Error),
@@ -1200,6 +1204,7 @@ impl Display for BuiltinFunctionKind {
             BuiltinFunctionKind::Tablesize => write!(f, "__tablesize"),
             BuiltinFunctionKind::Codesize => write!(f, "__codesize"),
             BuiltinFunctionKind::Tablestart => write!(f, "__tablestart"),
+            BuiltinFunctionKind::EmbedTable => write!(f, "__EMBED_TABLE"),
             BuiltinFunctionKind::FunctionSignature => write!(f, "__FUNC_SIG"),
             BuiltinFunctionKind::EventHash => write!(f, "__EVENT_HASH"),
             BuiltinFunctionKind::Error => write!(f, "__ERROR"),
@@ -1221,6 +1226,7 @@ impl BuiltinFunctionKind {
             "__tablesize"
                 | "__codesize"
                 | "__tablestart"
+                | "__EMBED_TABLE"
                 | "__FUNC_SIG"
                 | "__EVENT_HASH"
                 | "__ERROR"

--- a/crates/utils/src/bytecode.rs
+++ b/crates/utils/src/bytecode.rs
@@ -582,6 +582,8 @@ pub struct BytecodeRes {
     pub table_instances: Jumps,
     /// Utilized Tables
     pub utilized_tables: Vec<TableDefinition>,
+    /// Embedded Tables (table name -> first embedding offset)
+    pub embedded_tables: BTreeMap<String, usize>,
 }
 
 impl Display for BytecodeRes {

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -228,6 +228,8 @@ pub enum CodegenErrorKind {
     /// Duplicate label defined in multiple sibling scopes
     /// When a label is not found in current scope, fallback searches siblings - but will always find the first definition, making subsequent ones unreachable
     DuplicateLabelAcrossSiblings(String),
+    /// Duplicate Table Embedding
+    DuplicateTableEmbedding(String),
     /// Jump target is too large for the specified opcode
     JumpTargetTooLarge {
         /// The label name
@@ -356,6 +358,9 @@ impl<W: Write> Report<W> for CodegenError {
             }
             CodegenErrorKind::DuplicateLabelAcrossSiblings(label) => {
                 write!(f.out, "Duplicate label '{}' defined across siblings in same scope", label)
+            }
+            CodegenErrorKind::DuplicateTableEmbedding(table) => {
+                write!(f.out, "Table \"{}\" has already been embedded. Each table can only be embedded once with __EMBED_TABLE.", table)
             }
             CodegenErrorKind::JumpTargetTooLarge { label, target, opcode } => {
                 write!(f.out, "Jump target {:#x} too large for {} in label \"{}\"", target, opcode, label)
@@ -719,6 +724,9 @@ impl fmt::Display for CompilerError {
                 }
                 CodegenErrorKind::DuplicateLabelAcrossSiblings(label) => {
                     write!(f, "\nError: Duplicate label '{}' defined across siblings in same scope\n{}\n", label, ce.span.error(None))
+                }
+                CodegenErrorKind::DuplicateTableEmbedding(table) => {
+                    write!(f, "\nError: Table \"{}\" has already been embedded\n{}\n", table, ce.span.error(None))
                 }
                 CodegenErrorKind::JumpTargetTooLarge { label, target, opcode } => {
                     write!(


### PR DESCRIPTION
- Correctly handle decimal literals in for loop bounds (have been interpreted as hex before).
  - Example: `for(i in 0..255)` and `for(i in 0..0xff)` are now equivalent.
- Add `__EMBED_TABLE(TABLE_NAME)` builtin function to embed code tables inline.
  - Embeds table bytes at the current position instead of at the end of bytecode.
  - Each table can only be embedded once to avoid ambiguity.
  - `__tablestart(TABLE)` returns the inline embedding position for embedded tables.