### PR TITLE
fix: allow constant defined with a builtin function assigned used in a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+- Fix constants defined with builtin functions not working in code tables (fixes #149).
+  - Example: `#define constant C = __RIGHTPAD(0x)` can now be used in tables with `[C]`.
 
 ## [1.5.5] - 2025-11-08
 - Fix `--relax-jumps` not updating label positions always correct during iterative optimization.

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -239,6 +239,15 @@ impl Codegen {
                             let literal = contract.evaluate_constant_expression(expr)?;
                             Bytes::Raw(bytes_util::bytes32_to_hex_string(&literal, false))
                         }
+                        ConstVal::BuiltinFunctionCall(bf) => {
+                            let push_value = Codegen::gen_builtin_bytecode(contract, bf, statement.span.clone())?;
+                            // Use full hex for padding functions (always 32 bytes), trimmed for others
+                            let hex_data = match bf.kind {
+                                BuiltinFunctionKind::LeftPad | BuiltinFunctionKind::RightPad => push_value.to_hex_full(),
+                                _ => push_value.to_hex_trimmed(),
+                            };
+                            Bytes::Raw(hex_data)
+                        }
                         _ => {
                             return Err(CodegenError {
                                 kind: CodegenErrorKind::InvalidArguments("Constant must be a hex literal or expression".to_string()),


### PR DESCRIPTION
- Fix constants defined with builtin functions not working in code tables (fixes #149).
  - Example: `#define constant C = __RIGHTPAD(0x)` can now be used in tables with `[C]`.