### PR TITLE
feat: support to pass builtin functions to `__VERBATIM`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+- Add support to pass builtin functions to `__VERBATIM`.
+  - `__VERBATIM` can now wrap builtins that generate PUSH + value, stripping the PUSH opcode.
+  - Supported: `__FUNC_SIG`, `__EVENT_HASH`, `__BYTES`, `__ERROR`, `__RIGHTPAD`, `__LEFTPAD`.
+  - Example: `__VERBATIM(__FUNC_SIG("withdraw(uint256)"))` emits raw 4-byte selector without PUSH4.
 
 ## [1.5.8] - 2025-11-29
 - Fix `__RIGHTPAD()` incorrectly padding odd-length hex values.

--- a/crates/core/tests/verbatim.rs
+++ b/crates/core/tests/verbatim.rs
@@ -92,3 +92,139 @@ fn test_verbatim_with_builtin_constant() {
         Err(_) => panic!("moose"),
     }
 }
+
+#[test]
+fn test_verbatim_with_nested_func_sig() {
+    let source = r#"
+    #define macro MAIN() = takes(0) returns(0) {
+        __VERBATIM(__FUNC_SIG("withdraw(uint256)"))
+    }
+    "#;
+
+    let full_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(full_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, Some("".to_string()));
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // keccak256("withdraw(uint256)")[0:4] = 0x2e1a7d4d
+    match Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false) {
+        Ok(mb) => assert_eq!(mb, "2e1a7d4d".to_string()),
+        Err(e) => panic!("Failed to generate bytecode: {:?}", e),
+    }
+}
+
+#[test]
+fn test_verbatim_with_nested_event_hash() {
+    let source = r#"
+    #define macro MAIN() = takes(0) returns(0) {
+        __VERBATIM(__EVENT_HASH("Transfer(address,address,uint256)"))
+    }
+    "#;
+
+    let full_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(full_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, Some("".to_string()));
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // keccak256("Transfer(address,address,uint256)")
+    match Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false) {
+        Ok(mb) => assert_eq!(mb, "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef".to_string()),
+        Err(e) => panic!("Failed to generate bytecode: {:?}", e),
+    }
+}
+
+#[test]
+fn test_verbatim_with_nested_bytes() {
+    let source = r#"
+    #define macro MAIN() = takes(0) returns(0) {
+        __VERBATIM(__BYTES("hello"))
+    }
+    "#;
+
+    let full_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(full_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, Some("".to_string()));
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // "hello" in UTF-8 hex = 68656c6c6f
+    match Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false) {
+        Ok(mb) => assert_eq!(mb, "68656c6c6f".to_string()),
+        Err(e) => panic!("Failed to generate bytecode: {:?}", e),
+    }
+}
+
+#[test]
+fn test_verbatim_with_nested_error() {
+    let source = r#"
+    #define error CustomError()
+
+    #define macro MAIN() = takes(0) returns(0) {
+        __VERBATIM(__ERROR(CustomError))
+    }
+    "#;
+
+    let full_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(full_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, Some("".to_string()));
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // __ERROR with error definition puts selector at start, right-padded to 32 bytes
+    // keccak256("CustomError()")[0:4] = 0x09caebf3
+    // Right-padded to 32 bytes: 09caebf3000...000
+    match Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false) {
+        Ok(mb) => assert_eq!(mb, "09caebf300000000000000000000000000000000000000000000000000000000".to_string()),
+        Err(e) => panic!("Failed to generate bytecode: {:?}", e),
+    }
+}
+
+#[test]
+fn test_verbatim_with_nested_rightpad() {
+    let source = r#"
+    #define macro MAIN() = takes(0) returns(0) {
+        __VERBATIM(__RIGHTPAD(0x1234))
+    }
+    "#;
+
+    let full_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(full_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, Some("".to_string()));
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // __RIGHTPAD(0x1234) = 0x1234 followed by 30 zero bytes
+    match Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false) {
+        Ok(mb) => assert_eq!(mb, "1234000000000000000000000000000000000000000000000000000000000000".to_string()),
+        Err(e) => panic!("Failed to generate bytecode: {:?}", e),
+    }
+}
+
+#[test]
+fn test_verbatim_with_nested_leftpad() {
+    let source = r#"
+    #define macro MAIN() = takes(0) returns(0) {
+        __VERBATIM(__LEFTPAD(0x1234))
+    }
+    "#;
+
+    let full_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(full_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, Some("".to_string()));
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // __LEFTPAD(0x1234) = 30 zero bytes followed by 0x1234
+    match Codegen::generate_main_bytecode(&EVMVersion::default(), &contract, None, false) {
+        Ok(mb) => assert_eq!(mb, "0000000000000000000000000000000000000000000000000000000000001234".to_string()),
+        Err(e) => panic!("Failed to generate bytecode: {:?}", e),
+    }
+}

--- a/spec/grammar/huff-neo.pest
+++ b/spec/grammar/huff-neo.pest
@@ -323,6 +323,11 @@ builtin_assert_pc_arg = { literal_hex | ref_constant_bracketed }
 // Accept: string literals or string constant references (constants that are strings)
 builtin_bytes_arg = { literal_string | ref_constant_bracketed }
 
+// Verbatim builtin: __VERBATIM
+// Accept: hex literals, constant references, or builtin function calls (strips PUSH opcode)
+// Example: __VERBATIM(0x1234), __VERBATIM([MY_CONST]), __VERBATIM(__FUNC_SIG("transfer(address,uint256)"))
+builtin_verbatim_arg = { literal_hex | ref_constant_bracketed | invoke_builtin }
+
 // EXPRESSION PRIMARIES: Atomic values in compile-time expressions
 // Used in: constant definitions, for loop ranges, if conditions, value-based builtins
 // Includes:
@@ -513,7 +518,7 @@ builtin_function_call = {
     | "__RIGHTPAD" ~ "(" ~ arithmetic_expr ~ "," ~ arithmetic_expr ~ ")"
     | "__LEFTPAD" ~ "(" ~ arithmetic_expr ~ "," ~ arithmetic_expr ~ ")"
     | "__CODECOPY_DYN_ARG" ~ "(" ~ literal_decimal ~ ")"
-    | "__VERBATIM" ~ "(" ~ literal_hex ~ ")"
+    | "__VERBATIM" ~ "(" ~ builtin_verbatim_arg ~ ")"
     | "__BYTES" ~ "(" ~ builtin_bytes_arg ~ ")"
     | "__ASSERT_PC" ~ "(" ~ builtin_assert_pc_arg ~ ")"
 }


### PR DESCRIPTION
- Add support to pass builtin functions to `__VERBATIM`.
  - `__VERBATIM` can now wrap builtins that generate PUSH + value, stripping the PUSH opcode.
  - Supported: `__FUNC_SIG`, `__EVENT_HASH`, `__BYTES`, `__ERROR`, `__RIGHTPAD`, `__LEFTPAD`.
  - Example: `__VERBATIM(__FUNC_SIG("withdraw(uint256)"))` emits raw 4-byte selector without PUSH4.