### PR TITLE
chore: update dependencies and make Osaka default

### DIFF
--- a/.github/workflows/release-wasm.yaml
+++ b/.github/workflows/release-wasm.yaml
@@ -9,6 +9,9 @@ jobs:
   release-npm:
     name: Release NPM
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC
 
     steps:
       - uses: actions/checkout@v4
@@ -16,6 +19,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Get version tag
         id: vars
@@ -31,11 +39,6 @@ jobs:
           PACKAGE_VERSION: ${{ steps.vars.outputs.tag }}
         run: .github/scripts/make_package.sh
 
-      - name: Authenticate with NPM
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-
       - name: Publish to NPM
-        run: npm publish
+        run: npm publish --provenance --access public
         working-directory: ./crates/js/pkg
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+
+## [1.5.9] - 2025-12-24
 - Add support to pass builtin functions to `__VERBATIM`.
   - `__VERBATIM` can now wrap builtins that generate PUSH + value, stripping the PUSH opcode.
   - Supported: `__FUNC_SIG`, `__EVENT_HASH`, `__BYTES`, `__ERROR`, `__RIGHTPAD`, `__LEFTPAD`.
   - Example: `__VERBATIM(__FUNC_SIG("withdraw(uint256)"))` emits raw 4-byte selector without PUSH4.
+- EVM version `Osaka` is now the default.
+- Update to foundry v1.5.1.
 
 ## [1.5.8] - 2025-11-29
 - Fix `__RIGHTPAD()` incorrectly padding odd-length hex values.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,8 +1003,8 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -1067,8 +1067,8 @@ dependencies = [
 
 [[package]]
 name = "anvil-core"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -1094,8 +1094,8 @@ dependencies = [
 
 [[package]]
 name = "anvil-rpc"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1103,8 +1103,8 @@ dependencies = [
 
 [[package]]
 name = "anvil-server"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "anvil-rpc",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2921,7 +2921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3116,8 +3116,8 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "forge-script-sequence"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3160,8 +3160,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3213,8 +3213,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes-spec"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-sol-types",
  "foundry-macros",
@@ -3223,8 +3223,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-cli"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
@@ -3269,8 +3269,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-common"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3325,8 +3325,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-common-fmt"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -3440,8 +3440,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-config"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -3479,8 +3479,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-debugger"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-primitives",
  "crossterm 0.29.0",
@@ -3498,8 +3498,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-evm",
@@ -3531,8 +3531,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-abi"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3544,8 +3544,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-core"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3584,8 +3584,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-coverage"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3601,8 +3601,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-fuzz"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3627,8 +3627,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-networks"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-chains",
  "alloy-evm",
@@ -3640,8 +3640,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-traces"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3697,8 +3697,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-linking"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-primitives",
  "foundry-compilers",
@@ -3709,8 +3709,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-macros"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -3720,8 +3720,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-wallets"
-version = "1.5.0"
-source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.0#1c57854462289b2e71ee7654cd6666217ed86ffd"
+version = "1.5.1"
+source = "git+https://github.com/foundry-rs/foundry?tag=v1.5.1#b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "hnc"
-version = "1.5.8"
+version = "1.5.9"
 dependencies = [
  "alloy-primitives",
  "assert_cmd",
@@ -4175,7 +4175,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "huff-neo-codegen"
-version = "1.5.8"
+version = "1.5.9"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-core"
-version = "1.5.8"
+version = "1.5.9"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-js"
-version = "1.5.8"
+version = "1.5.9"
 dependencies = [
  "huff-neo-core",
  "huff-neo-utils",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-lexer"
-version = "1.5.8"
+version = "1.5.9"
 dependencies = [
  "huff-neo-utils",
  "lazy_static",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-parser"
-version = "1.5.8"
+version = "1.5.9"
 dependencies = [
  "alloy-primitives",
  "huff-neo-lexer",
@@ -4242,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-test-runner"
-version = "1.5.8"
+version = "1.5.9"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-utils"
-version = "1.5.8"
+version = "1.5.9"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4665,7 +4665,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5117,7 +5117,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6007,7 +6007,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6656,7 +6656,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7585,9 +7585,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs"
-version = "0.5.21"
+version = "0.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521753eee64c5f03163f631298ca9184ed4bc6e632d101c781075c5bb4ca755f"
+checksum = "909e8ff825120cd2b34ceb236ab72e2a7f74b1d3a86c247936c8ff7a80c5d408"
 dependencies = [
  "const-hex",
  "dirs",
@@ -7597,16 +7597,16 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.5.21"
+version = "0.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c643d522c474be805787a2813b89a179d71afec3540b18d79c5936d9c24bf3e5"
+checksum = "c1ebe77b200f965e8dbec3ef1d8337e974179ca1ecaa9fc28f67288d6b438159"
 dependencies = [
  "const-hex",
  "semver 1.0.27",
@@ -7705,7 +7705,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8733,7 +8733,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/foundry-rs/huff-neo"
 rust-version = "1.89"
-version = "1.5.8"
+version = "1.5.9"
 
 [workspace.dependencies]
 huff-neo-codegen = { path = "crates/codegen" }
@@ -52,16 +52,17 @@ op-revm = { version = "14.0.0", default-features = false }
 revm = { version = "33.0.0", default-features = false, features = ["optional_no_base_fee"] }
 
 # foundry
-anvil = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.0" }
-foundry-cli = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.0" }
-foundry-common = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.0" }
-foundry-compilers = { version = "0.19.5", default-features = false }
-foundry-config = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.0" }
-foundry-debugger = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.0" }
-foundry-evm = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.0" }
-foundry-evm-core = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.0" }
-foundry-evm-networks = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.0" }
-foundry-evm-traces = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.0" }
+anvil = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.1" }
+foundry-cli = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.1" }
+foundry-common = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.1" }
+foundry-compilers = { version = "0.19.10", default-features = false }
+foundry-config = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.1" }
+foundry-debugger = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.1" }
+foundry-evm = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.1" }
+foundry-evm-core = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.1" }
+foundry-evm-networks = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.1" }
+foundry-evm-traces = { git = "https://github.com/foundry-rs/foundry", tag = "v1.5.1" }
+
 
 # serde
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Huff Contributors"]
 language = "en"
-multilingual = false
 src = "book"
 title = "Huff Langugage / huff-neo - Documentation"
 

--- a/crates/lexer/tests/constant.rs
+++ b/crates/lexer/tests/constant.rs
@@ -8,9 +8,9 @@ fn constant_hex_literal_too_long() {
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     for token_result in lexer {
-        if token_result.is_err() {
+        if let Err(err) = token_result {
             assert_eq!(
-                token_result.unwrap_err().kind,
+                err.kind,
                 LexicalErrorKind::HexLiteralTooLong("0x000000000000000000000000000000000000000000000000000000000000000000".to_string())
             );
             return;
@@ -25,8 +25,8 @@ fn constant_invalid_hex_literal() {
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source);
     for tok in lexer {
-        if tok.is_err() {
-            assert_eq!(tok.unwrap_err().kind, LexicalErrorKind::InvalidHexLiteral("0x0x".to_string()));
+        if let Err(err) = tok {
+            assert_eq!(err.kind, LexicalErrorKind::InvalidHexLiteral("0x0x".to_string()));
             return;
         }
     }

--- a/crates/utils/src/evm_version.rs
+++ b/crates/utils/src/evm_version.rs
@@ -22,13 +22,13 @@ pub enum SupportedEVMVersions {
     /// Prague/Electra - No new opcodes
     ///
     /// Meta: <https://eips.ethereum.org/EIPS/eip-7600>
-    #[default]
     Prague,
     /// Fulu/Osaka - Introduced CLZ
     ///
     ///
     /// Meta: <https://eips.ethereum.org/EIPS/eip-7607>
     /// CLZ: <https://eips.ethereum.org/EIPS/eip-7939>
+    #[default]
     Osaka,
 }
 


### PR DESCRIPTION
- EVM version `Osaka` is now the default.
- Update to foundry v1.5.1.