### PR TITLE
fix(codegen): place constructor tables past main so auto-bootstrap can execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+- Fix `__tablestart` in `CONSTRUCTOR` corrupting the auto-generated bootstrap. Tables were placed
+  between the constructor body and the bootstrap, so execution fell into table bytes before the
+  bootstrap ran. Constructor-only tables now sit past `main` in the deployment tail; tables shared
+  between `CONSTRUCTOR` and `MAIN` are emitted once (in the runtime) and the constructor's
+  `__tablestart` resolves into that copy.
+
+  ```text
+  before: [ctor_body][ctor_tables][bootstrap][main_body][main_tables][args]
+                                  ↑ unreachable
+
+  after:  [ctor_body][bootstrap][main_body][main_tables][ctor_only_tables][args]
+                                ========================
+                                deployed runtime code
+  ```
+
+  Note: `--relax-jumps` only shrinks JUMP/JUMPI placeholders; `__tablestart` stays `PUSH2`.
 
 ## [1.5.14] - 2026-02-03
 - **Breaking**: Enforce EIP-170 contract size limit (24,576 bytes) by default.

--- a/book/huff-language/macros-and-functions.md
+++ b/book/huff-language/macros-and-functions.md
@@ -39,6 +39,45 @@ as the contract's runtime bytecode. If the constructor contains a `RETURN` opcod
 will not include this bootstrap, and it will instead instantiate the contract with the code returned
 by the constructor.
 
+#### Table scopes in `CONSTRUCTOR` and `MAIN`
+
+Tables referenced via `__tablestart` sit in different parts of the deployment bytecode depending
+on which scope references them:
+
+```text
+[ctor_body][bootstrap][main_body][main_tables][ctor_only_tables][args]
+                      ==============================
+                      runtime — stored on-chain
+```
+
+- Referenced from `MAIN` → emitted inside the runtime; `__tablestart(T)` is the offset within the
+  runtime.
+- Referenced only from `CONSTRUCTOR` → emitted in the deployment tail past `main`. The constructor
+  can read it during deployment, but it is **not** stored on-chain.
+- Referenced from both → emitted once in the runtime section. The constructor's `__tablestart(T)`
+  resolves into that shared copy; no duplicate is written to the tail.
+
+Example of a shared table read from both scopes:
+
+```javascript
+#define table CONFIG {
+    0x00000000000000000000000000000000000000000000000000000000deadbeef
+    0x00000000000000000000000000000000000000000000000000000000cafebabe
+}
+
+#define macro CONSTRUCTOR() = takes (0) returns (0) {
+    // Copy CONFIG into memory at 0x00 and store the first word in slot 0.
+    __tablesize(CONFIG) __tablestart(CONFIG) 0x00 codecopy
+    0x00 mload 0x00 sstore
+}
+
+#define macro MAIN() = takes (0) returns (0) {
+    // Read the second word of CONFIG and return it.
+    __tablestart(CONFIG) 0x20 add 0x00 codecopy
+    0x20 0x00 return
+}
+```
+
 ### Macro Arguments
 
 Macros can accept arguments, which can be used within the macro itself or passed as reference. These arguments can be labels, opcodes, literals, constants, or other macro calls. Since macros are inlined at compile time, their arguments are also inlined and not evaluated at runtime.

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -104,8 +104,8 @@ impl MainBytecodeOutput {
 
 /// Constructor macro bytecode produced by phase 1, prior to table resolution and bootstrap insertion.
 ///
-/// The unresolved [`BytecodeRes`] is forwarded to [`Codegen::build_artifact`] (phase 2) which knows
-/// the bootstrap size and runtime layout, and finalizes `__tablestart` resolution from there.
+/// The unresolved [`BytecodeRes`] is forwarded to [`Codegen::assemble_artifact`] (phase 2) which
+/// knows the bootstrap size and runtime layout, and finalizes `__tablestart` resolution from there.
 #[derive(Debug, Clone)]
 pub struct ConstructorMacroBytecode {
     /// Unresolved bytecode result for the constructor macro body.

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -62,6 +62,59 @@ pub struct Codegen {
     pub constructor_bytecode: Option<String>,
 }
 
+/// Output of [`Codegen::gen_table_bytecode`].
+///
+/// Body bytecode (with `__tablestart` placeholders filled), the table bytecode emitted by this call,
+/// and the absolute deployment-bytecode offsets at which those tables sit.
+#[derive(Debug, Default, Clone)]
+pub struct TableBytecodeOutput {
+    /// Body bytecode hex string, with all `__tablestart` placeholders replaced.
+    pub body: String,
+    /// Table bytecode hex string for tables emitted by this call. The caller decides where to place
+    /// this in the overall deployment bytecode.
+    pub tables: String,
+    /// Map of locally-emitted table name to its absolute deployment-bytecode offset.
+    pub local_table_offsets: HashMap<String, usize>,
+    /// Source map for the body bytecode.
+    pub source_map: Vec<SourceMapEntry>,
+}
+
+/// Output of [`Codegen::generate_main_bytecode_with_sourcemap`].
+///
+/// `bytecode` is the runtime bytes (body + appended tables). `table_offsets` maps each
+/// runtime-resident table to its offset within the runtime. The constructor finalization step uses
+/// `table_offsets` to dedupe any `__tablestart` reference shared with main.
+#[derive(Debug, Default, Clone)]
+pub struct MainBytecodeOutput {
+    /// Full main/runtime bytecode (body + appended tables) as a hex string.
+    pub bytecode: String,
+    /// Source map for the runtime bytecode body.
+    pub source_map: Vec<SourceMapEntry>,
+    /// Per-table runtime-relative offsets for tables appended to the runtime body.
+    pub table_offsets: HashMap<String, usize>,
+}
+
+impl MainBytecodeOutput {
+    /// Byte offset within the runtime at which the appended tables begin (equivalently, the length
+    /// of the runtime body). When no tables are appended, this equals the full runtime length.
+    pub fn body_len(&self) -> usize {
+        self.table_offsets.values().min().copied().unwrap_or(self.bytecode.len() / 2)
+    }
+}
+
+/// Constructor macro bytecode produced by phase 1, prior to table resolution and bootstrap insertion.
+///
+/// The unresolved [`BytecodeRes`] is forwarded to [`Codegen::build_artifact`] (phase 2) which knows
+/// the bootstrap size and runtime layout, and finalizes `__tablestart` resolution from there.
+#[derive(Debug, Clone)]
+pub struct ConstructorMacroBytecode {
+    /// Unresolved bytecode result for the constructor macro body.
+    pub bytecode_res: BytecodeRes,
+    /// `true` when the constructor body already contains a `RETURN` (`0xf3`) opcode, indicating the
+    /// user supplies their own deployment bootstrap and the compiler should not emit one.
+    pub has_custom_bootstrap: bool,
+}
+
 impl Codegen {
     /// Public associated function to instantiate a new Codegen instance.
     pub fn new() -> Self {
@@ -82,19 +135,22 @@ impl Codegen {
         alternative_main: Option<String>,
         relax_jumps: bool,
     ) -> Result<String, CodegenError> {
-        let (bytecode, _source_map) = Self::generate_main_bytecode_with_sourcemap(evm_version, contract, alternative_main, relax_jumps)?;
-        Ok(bytecode)
+        let out = Self::generate_main_bytecode_with_sourcemap(evm_version, contract, alternative_main, relax_jumps)?;
+        Ok(out.bytecode)
     }
 
     /// Compiles the contract's main macro into bytecode with source map.
     ///
-    /// Like `generate_main_bytecode`, but also returns a source map for debugging.
+    /// Returns the full main bytecode (body + appended tables), its source map, the length of the
+    /// body section (offset at which the runtime tables begin), and the per-table runtime offsets.
+    /// `build_artifact` uses the body length and table offsets to dedupe constructor-side
+    /// `__tablestart` references into the runtime copy.
     pub fn generate_main_bytecode_with_sourcemap(
         evm_version: &EVMVersion,
         contract: &Contract,
         alternative_main: Option<String>,
         relax_jumps: bool,
-    ) -> Result<(String, Vec<SourceMapEntry>), CodegenError> {
+    ) -> Result<MainBytecodeOutput, CodegenError> {
         // Update table sizes
         let contract = Self::update_table_size(evm_version, contract)?;
 
@@ -114,29 +170,43 @@ impl Codegen {
 
         tracing::debug!(target: "codegen", "Generated main bytecode. Appending table bytecode...");
 
-        // Generate the fully baked bytecode
-        Codegen::gen_table_bytecode(&contract, bytecode_res)
+        // Main bytecode is not shifted by a bootstrap and has no upstream dedup map.
+        let table_out = Codegen::gen_table_bytecode(&contract, bytecode_res, 0, &HashMap::new())?;
+        let bytecode = format!("{}{}", table_out.body, table_out.tables);
+        Ok(MainBytecodeOutput { bytecode, source_map: table_out.source_map, table_offsets: table_out.local_table_offsets })
     }
 
-    /// Generates constructor bytecode from a Contract AST
+    /// Generates the constructor section in isolation: macro body with all `__tablestart`
+    /// placeholders resolved against locally-emitted tables.
+    ///
+    /// This standalone form (tables sitting directly after the body) does not include the
+    /// deployment-time auto-bootstrap and is **not** the layout that ends up in the deployed
+    /// artifact — use [`Codegen::churn`] for the final assembly. This function exists for tools
+    /// and tests that want to inspect just the constructor section.
     pub fn generate_constructor_bytecode(
         evm_version: &EVMVersion,
         contract: &Contract,
         alternative_constructor: Option<String>,
         relax_jumps: bool,
     ) -> Result<(String, bool), CodegenError> {
-        let ((bytecode, _source_map), has_custom) =
-            Self::generate_constructor_bytecode_with_sourcemap(evm_version, contract, alternative_constructor, relax_jumps)?;
-        Ok((bytecode, has_custom))
+        let (ctor, contract) = Self::generate_constructor_macro_bytecode(evm_version, contract, alternative_constructor, relax_jumps)?;
+        let has_custom_bootstrap = ctor.has_custom_bootstrap;
+        let out = Codegen::gen_table_bytecode(&contract, ctor.bytecode_res, 0, &HashMap::new())?;
+        Ok((format!("{}{}", out.body, out.tables), has_custom_bootstrap))
     }
 
-    /// Generates constructor bytecode with source map from a Contract AST
-    pub fn generate_constructor_bytecode_with_sourcemap(
+    /// Generates constructor macro bytecode without resolving `__tablestart` placeholders.
+    ///
+    /// This is phase 1 of constructor codegen. Table positions and `__tablestart` resolution depend
+    /// on the auto-bootstrap size and the runtime layout, which are only known once `build_artifact`
+    /// has both the constructor body and the compiled main bytecode in hand. Phase 2 runs inside
+    /// `build_artifact` via [`Codegen::gen_table_bytecode`].
+    pub fn generate_constructor_macro_bytecode(
         evm_version: &EVMVersion,
         contract: &Contract,
         alternative_constructor: Option<String>,
         relax_jumps: bool,
-    ) -> Result<((String, Vec<SourceMapEntry>), bool), CodegenError> {
+    ) -> Result<(ConstructorMacroBytecode, Contract), CodegenError> {
         // Update table sizes
         let contract = Self::update_table_size(evm_version, contract)?;
 
@@ -154,14 +224,13 @@ impl Codegen {
         let bytecode_res: BytecodeRes =
             Codegen::macro_to_bytecode(evm_version, c_macro, &contract, &mut scope_mgr, 0, false, None, relax_jumps)?;
 
-        // Check if the constructor performs its own code generation
+        // A constructor body containing a RETURN means the user is supplying their own deployment
+        // bootstrap; suppress the compiler's auto-bootstrap in that case.
         let has_custom_bootstrap = bytecode_res.bytes.iter().any(|seg| seg.bytes.as_str() == "f3");
 
         tracing::info!(target: "codegen", "Constructor is self-generating: {}", has_custom_bootstrap);
 
-        let (bytecode, source_map) = Codegen::gen_table_bytecode(&contract, bytecode_res)?;
-
-        Ok(((bytecode, source_map), has_custom_bootstrap))
+        Ok((ConstructorMacroBytecode { bytecode_res, has_custom_bootstrap }, contract))
     }
 
     /// Update the table size in the contract that was not know at the time of parsing
@@ -273,10 +342,20 @@ impl Codegen {
         Ok(byte_code)
     }
 
-    /// Appends table bytecode to the end of the BytecodeRes output.
-    /// Fills table JUMPDEST placeholders.
-    /// Returns both the bytecode string and the source map
-    pub fn gen_table_bytecode(contract: &Contract, res: BytecodeRes) -> Result<(String, Vec<SourceMapEntry>), CodegenError> {
+    /// Appends table bytecode for tables referenced by `res` and fills `__tablestart` placeholders.
+    ///
+    /// `base_offset` is added to every locally-emitted table's offset before resolution — used by the
+    /// constructor pathway to push tables past the auto-bootstrap and main bytecode.
+    ///
+    /// `external_table_offsets` lets the caller resolve `__tablestart` to a table emitted somewhere
+    /// else (e.g. shared with the runtime). Tables found here are not emitted locally; their offset
+    /// is used directly when filling placeholders.
+    pub fn gen_table_bytecode(
+        contract: &Contract,
+        res: BytecodeRes,
+        base_offset: usize,
+        external_table_offsets: &HashMap<String, usize>,
+    ) -> Result<TableBytecodeOutput, CodegenError> {
         if !res.unmatched_jumps.is_empty() {
             let labels = res.unmatched_jumps.iter().map(|uj| uj.label.to_string()).collect::<Vec<String>>();
             tracing::error!(
@@ -334,9 +413,11 @@ impl Codegen {
             program_counter += instruction_bytecode_length; // Advance PC by the bytecode length
         }
 
-        let mut bytecode = res.bytes.into_iter().map(|seg| seg.bytes.as_str().to_string()).collect::<String>();
-        let mut table_offsets: HashMap<String, usize> = HashMap::new(); // table name -> bytecode offset
-        let mut table_offset = bytecode.len() / 2;
+        let mut body = res.bytes.into_iter().map(|seg| seg.bytes.as_str().to_string()).collect::<String>();
+        let body_len = body.len() / 2;
+        let mut tables_bytecode = String::new();
+        let mut local_table_offsets: HashMap<String, usize> = HashMap::new();
+        let mut table_offset = body_len + base_offset;
 
         res.utilized_tables.iter().try_for_each(|jt| {
             // Skip tables that were embedded inline
@@ -344,8 +425,13 @@ impl Codegen {
                 tracing::debug!(target: "codegen", "Skipping embedded table \"{}\" from end-placement", jt.name);
                 return Ok(());
             }
+            // Skip tables resolved via an external (dedup) map
+            if external_table_offsets.contains_key(&jt.name) {
+                tracing::debug!(target: "codegen", "Resolving table \"{}\" via external offset map", jt.name);
+                return Ok(());
+            }
 
-            table_offsets.insert(jt.name.to_string(), table_offset);
+            local_table_offsets.insert(jt.name.to_string(), table_offset);
 
             let Some(table_size) = &jt.size else {
                 return Err(CodegenError {
@@ -371,7 +457,7 @@ impl Codegen {
             if jt.kind == TableKind::CodeTable {
                 let table_code = Codegen::gen_table_bytecode_builtin(contract, jt)?;
 
-                bytecode = format!("{bytecode}{table_code}");
+                tables_bytecode.push_str(&table_code);
                 return Ok(());
             }
 
@@ -413,19 +499,22 @@ impl Codegen {
                 Ok(())
             })?;
             tracing::info!(target: "codegen", "SUCCESSFULLY GENERATED BYTECODE FOR TABLE: \"{}\"", jt.name);
-            bytecode = format!("{bytecode}{table_code}");
+            tables_bytecode.push_str(&table_code);
             Ok(())
         })?;
 
         res.table_instances.iter().for_each(|jump| {
-            // Check both end-placed tables and embedded tables
-            let offset_opt = table_offsets.get(&jump.label).or_else(|| res.embedded_tables.get(&jump.label));
+            // Resolution order: locally-emitted, then external (dedup) map, then embedded inline.
+            let offset_opt = local_table_offsets
+                .get(&jump.label)
+                .or_else(|| external_table_offsets.get(&jump.label))
+                .or_else(|| res.embedded_tables.get(&jump.label));
 
             if let Some(o) = offset_opt {
-                let before = &bytecode[0..jump.bytecode_index * 2 + 2];
-                let after = &bytecode[jump.bytecode_index * 2 + 6..];
+                let before = &body[0..jump.bytecode_index * 2 + 2];
+                let after = &body[jump.bytecode_index * 2 + 6..];
 
-                bytecode = format!("{before}{}{after}", pad_n_bytes(format!("{o:02x}").as_str(), 2));
+                body = format!("{before}{}{after}", pad_n_bytes(format!("{o:02x}").as_str(), 2));
                 tracing::info!(target: "codegen", "FILLED JUMPDEST FOR LABEL \"{}\"", jump.label);
             } else {
                 tracing::error!(
@@ -436,7 +525,7 @@ impl Codegen {
             }
         });
 
-        Ok((bytecode, source_map))
+        Ok(TableBytecodeOutput { body, tables: tables_bytecode, local_table_offsets, source_map })
     }
 
     /// Generates bytecode from a macro definition.
@@ -1129,24 +1218,73 @@ impl Codegen {
         Ok(bytes)
     }
 
-    /// Generate a codegen artifact
+    /// Back-compat shim for assembly from raw bytecode strings.
     ///
-    /// # Arguments
+    /// Synthesizes [`MainBytecodeOutput`] and [`ConstructorMacroBytecode`] from raw hex strings and
+    /// forwards to [`Codegen::assemble_artifact`]. Use this when you have pre-baked main and
+    /// constructor bytecode (e.g. existing snapshot tests) and do not need the table-dedup pathway.
     ///
-    /// * `args` - A vector of Tokens representing constructor arguments
-    /// * `main_bytecode` - The compiled MAIN Macro bytecode
-    /// * `constructor_bytecode` - The compiled `CONSTRUCTOR` Macro bytecode
-    /// * `no_size_limit` - Skip the EIP-170 contract size limit check
+    /// Behaves identically to the structured API for inputs that contain no tables.
     #[allow(clippy::too_many_arguments)]
     pub fn churn(
         &mut self,
         file: Arc<FileSource>,
-        mut args: Vec<alloy_dyn_abi::DynSolValue>,
+        args: Vec<alloy_dyn_abi::DynSolValue>,
         main_bytecode: &str,
         constructor_bytecode: &str,
         has_custom_bootstrap: bool,
         main_source_map: Option<Vec<SourceMapEntry>>,
         constructor_source_map: Option<Vec<SourceMapEntry>>,
+        no_size_limit: bool,
+    ) -> Result<Artifact, CodegenError> {
+        let main = MainBytecodeOutput {
+            bytecode: main_bytecode.to_string(),
+            source_map: main_source_map.unwrap_or_default(),
+            table_offsets: HashMap::new(),
+        };
+        let constructor = if constructor_bytecode.is_empty() {
+            None
+        } else {
+            let mut bytes = BytecodeSegments::new();
+            bytes.push_with_offset(0, Bytes::Raw(constructor_bytecode.to_string()));
+            let bytecode_res = BytecodeRes { bytes, ..Default::default() };
+            Some(ConstructorMacroBytecode { bytecode_res, has_custom_bootstrap })
+        };
+        // The shim does not have a fully-populated Contract — but with no utilized tables in the
+        // synthesized constructor BytecodeRes, gen_table_bytecode never inspects table definitions.
+        let contract = Contract::default();
+        let mut artifact = self.assemble_artifact(file, &contract, args, main, constructor, no_size_limit)?;
+        // Preserve the caller-supplied constructor source map (the shim doesn't generate one).
+        artifact.constructor_map = constructor_source_map;
+        Ok(artifact)
+    }
+
+    /// Generate a codegen artifact.
+    ///
+    /// Deployment bytecode is laid out as:
+    ///   `[ctor_body][bootstrap?][main_bytecode][ctor_only_tables][constructor_args]`
+    ///
+    /// A `__tablestart(T)` reference inside the constructor is resolved against a runtime-resident
+    /// copy of `T` when `main` already emits one (no duplicate); otherwise the table is appended
+    /// once to the deployment tail and the constructor's reference points there.
+    ///
+    /// # Arguments
+    ///
+    /// * `contract` — contract AST with table sizes populated by `update_table_size`. Used to read
+    ///   table definitions during constructor table finalization.
+    /// * `args` — encoded constructor arguments, appended at the very end of the deployment bytes.
+    /// * `main` — main/runtime bytecode plus its body length and per-table offsets within the runtime.
+    /// * `constructor` — phase-1 constructor macro output; `None` when the contract has no
+    ///   `CONSTRUCTOR` macro (deployment becomes just `bootstrap + main`).
+    /// * `no_size_limit` — skip the EIP-170 runtime size check.
+    #[allow(clippy::too_many_arguments)]
+    pub fn assemble_artifact(
+        &mut self,
+        file: Arc<FileSource>,
+        contract: &Contract,
+        mut args: Vec<alloy_dyn_abi::DynSolValue>,
+        main: MainBytecodeOutput,
+        constructor: Option<ConstructorMacroBytecode>,
         no_size_limit: bool,
     ) -> Result<Artifact, CodegenError> {
         let artifact: &mut Artifact = if let Some(art) = &mut self.artifact {
@@ -1156,11 +1294,9 @@ impl Codegen {
             self.artifact.as_mut().unwrap()
         };
 
-        // Move `main_bytecode` to the heap so that it can be modified if need be.
-        let mut main_bytecode = String::from(main_bytecode);
+        let MainBytecodeOutput { bytecode: mut main_bytecode, source_map: main_source_map, table_offsets: main_table_offsets } = main;
 
         let contract_length = main_bytecode.len() / 2;
-        let constructor_length = constructor_bytecode.len() / 2;
 
         // Check contract size limit (EIP-170)
         if !no_size_limit && contract_length > EIP170_CONTRACT_SIZE_LIMIT {
@@ -1170,6 +1306,59 @@ impl Codegen {
                 token: None,
             });
         }
+
+        // Compute the constructor body length and bootstrap size first, since the bootstrap size
+        // depends on the body length but not on constructor-only table sizes (under the new layout
+        // where constructor-only tables sit past main).
+        let (ctor_body_len, has_custom_bootstrap) = match &constructor {
+            // `Bytes::len()` returns size in bytes (not hex chars), so no further division needed.
+            Some(c) => (c.bytecode_res.bytes.iter().map(|seg| seg.bytes.len()).sum::<usize>(), c.has_custom_bootstrap),
+            None => (0, false),
+        };
+
+        // Bootstrap size depends only on body lengths (not table sizes).
+        // 9 bytes baseline (PUSH1 size, DUP1, PUSH1 offset, RETURNDATASIZE, CODECOPY, RETURNDATASIZE, RETURN);
+        // grows by 1 if PUSH2 is needed for contract_length, grows by another 1 if PUSH2 is needed
+        // for the runtime offset (= bootstrap_size + ctor_body_len).
+        let mut bootstrap_code_size = 9;
+        let contract_size = if contract_length < 256 {
+            // 60 = PUSH1
+            format!("60{}", pad_n_bytes(format!("{contract_length:x}").as_str(), 1))
+        } else {
+            bootstrap_code_size += 1;
+            // 61 = PUSH2
+            format!("61{}", pad_n_bytes(format!("{contract_length:x}").as_str(), 2))
+        };
+        let contract_code_offset = if (bootstrap_code_size + ctor_body_len) < 256 {
+            format!("60{}", pad_n_bytes(format!("{:x}", bootstrap_code_size + ctor_body_len).as_str(), 1))
+        } else {
+            bootstrap_code_size += 1;
+            format!("61{}", pad_n_bytes(format!("{:x}", bootstrap_code_size + ctor_body_len).as_str(), 2))
+        };
+
+        // 80 = DUP1; 3d = RETURNDATASIZE; 39 = CODECOPY; 3d = RETURNDATASIZE; f3 = RETURN.
+        // Suppressed entirely when the user supplies their own bootstrap (constructor contains RETURN).
+        let bootstrap_code =
+            if has_custom_bootstrap { String::default() } else { format!("{contract_size}80{contract_code_offset}3d393df3") };
+        let effective_bootstrap_size = if has_custom_bootstrap { 0 } else { bootstrap_code_size };
+
+        // Finalize constructor table resolution now that the layout is known.
+        // Constructor-only tables sit past main_bytecode in the deployment tail.
+        // Shared tables resolve into the runtime-resident copy at runtime_start + main_offset.
+        let runtime_start_in_deployment = ctor_body_len + effective_bootstrap_size;
+        // gen_table_bytecode internally adds body_len; only shift by what comes between body end
+        // and the constructor-only tables (bootstrap + main_bytecode).
+        let ctor_tables_base_offset = effective_bootstrap_size + contract_length;
+        let external_table_offsets: HashMap<String, usize> =
+            main_table_offsets.iter().map(|(name, off)| (name.clone(), runtime_start_in_deployment + off)).collect();
+
+        let (constructor_body, ctor_only_tables, constructor_source_map) = match constructor {
+            Some(c) => {
+                let out = Codegen::gen_table_bytecode(contract, c.bytecode_res, ctor_tables_base_offset, &external_table_offsets)?;
+                (out.body, out.tables, Some(out.source_map))
+            }
+            None => (String::new(), String::new(), None),
+        };
 
         // Sort constructor arguments so that statically sized args are inserted last.
         args.sort_by(|a, b| {
@@ -1182,7 +1371,10 @@ impl Codegen {
             }
         });
 
-        let mut arg_offset_acc = contract_length;
+        // `__CODECOPY_DYN_ARG` placeholders in main_bytecode are filled with the absolute
+        // deployment-bytecode offset where each argument's content sits. Args are appended past
+        // ctor_only_tables, so the first arg lives at runtime_start + contract_length + ctor_only_tables_len.
+        let mut arg_offset_acc = runtime_start_in_deployment + contract_length + ctor_only_tables.len() / 2;
         let encoded: Vec<Vec<u8>> = args
             .into_iter()
             .enumerate()
@@ -1245,37 +1437,12 @@ impl Codegen {
             });
         }
 
-        // Constructor size optimizations
-        let mut bootstrap_code_size = 9;
-        let contract_size = if contract_length < 256 {
-            // 60 = PUSH1
-            format!("60{}", pad_n_bytes(format!("{contract_length:x}").as_str(), 1))
-        } else {
-            bootstrap_code_size += 1;
-            // 61 = PUSH2
-            format!("61{}", pad_n_bytes(format!("{contract_length:x}").as_str(), 2))
-        };
-        let contract_code_offset = if (bootstrap_code_size + constructor_length) < 256 {
-            format!("60{}", pad_n_bytes(format!("{:x}", bootstrap_code_size + constructor_length).as_str(), 1))
-        } else {
-            bootstrap_code_size += 1;
-
-            format!("61{}", pad_n_bytes(format!("{:x}", bootstrap_code_size + constructor_length).as_str(), 2))
-        };
-
-        // 80 = DUP1
-        // 3d = RETURNDATASIZE, 39 = CODECOPY, 3d = RETURNDATASIZE, f3 = RETURN
-        let bootstrap_code =
-            if has_custom_bootstrap { String::default() } else { format!("{contract_size}80{contract_code_offset}3d393df3") };
-
-        // Generate the final bytecode
-        let constructor_code = format!("{constructor_bytecode}{bootstrap_code}");
-        artifact.bytecode = format!("{constructor_code}{main_bytecode}{constructor_args}").to_lowercase();
+        artifact.bytecode = format!("{constructor_body}{bootstrap_code}{main_bytecode}{ctor_only_tables}{constructor_args}").to_lowercase();
         artifact.runtime = main_bytecode.to_lowercase();
         artifact.file = file;
 
         // Set source maps if provided
-        artifact.runtime_map = main_source_map;
+        artifact.runtime_map = Some(main_source_map);
         artifact.constructor_map = constructor_source_map;
 
         Ok(artifact.clone())

--- a/crates/core/benches/huff_benchmark.rs
+++ b/crates/core/benches/huff_benchmark.rs
@@ -90,8 +90,8 @@ fn codegen_erc20_benchmark(c: &mut Criterion) {
     // Isolate codegen to benchmark
     c.bench_function("Codegen: ERC-20", |b| b.iter(|| {
         // Create main and constructor bytecode
-        let main_bytecode = Codegen::generate_main_bytecode(evm_version,&contract, None, false).unwrap();
-        let (constructor_bytecode, has_custom_bootstrap) = Codegen::generate_constructor_bytecode(evm_version,&contract, None, false).unwrap();
+        let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None, false).unwrap();
+        let (constructor_bytecode, has_custom_bootstrap) = Codegen::generate_constructor_bytecode(evm_version, &contract, None, false).unwrap();
 
         // Churn
         let mut cg = Codegen::new();
@@ -138,7 +138,7 @@ fn erc20_compilation_benchmark(c: &mut Criterion) {
         let evm_version = &EVMVersion::default();
 
         // Create main and constructor bytecode
-        let main_bytecode = Codegen::generate_main_bytecode(evm_version,&contract, None, false).unwrap();
+        let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None, false).unwrap();
         let (constructor_bytecode, has_custom_bootstrap) = Codegen::generate_constructor_bytecode(evm_version, &contract, None, false).unwrap();
 
         // Churn
@@ -187,7 +187,7 @@ fn erc721_compilation_benchmark(c: &mut Criterion) {
 
         // Create main and constructor bytecode
         let main_bytecode = Codegen::generate_main_bytecode(evm_version, &contract, None, false).unwrap();
-        let (constructor_bytecode, has_custom_bootstrap) = Codegen::generate_constructor_bytecode(evm_version,&contract, None, false).unwrap();
+        let (constructor_bytecode, has_custom_bootstrap) = Codegen::generate_constructor_bytecode(evm_version, &contract, None, false).unwrap();
 
         // Churn
         let mut cg = Codegen::new();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -482,7 +482,7 @@ impl<'a, 'l> Compiler<'a, 'l> {
 
         // Primary Bytecode Generation
         let mut cg = Codegen::new();
-        let (main_bytecode, main_source_map) = match Codegen::generate_main_bytecode_with_sourcemap(
+        let main = match Codegen::generate_main_bytecode_with_sourcemap(
             self.evm_version,
             &contract,
             self.alternative_main.clone(),
@@ -509,62 +509,59 @@ impl<'a, 'l> Compiler<'a, 'l> {
                 return Err(CompilerError::CodegenError(e));
             }
         };
-        tracing::info!(target: "core", "MAIN BYTECODE GENERATED [{}]", main_bytecode);
+        tracing::info!(target: "core", "MAIN BYTECODE GENERATED [{}]", main.bytecode);
 
-        // Generate Constructor Bytecode
+        // Order of constructor assembly:
+        //   1. generate_constructor_macro_bytecode — expand the macro into raw bytes, detect
+        //      whether the body contains its own RETURN (custom bootstrap).
+        //   2. assemble_artifact (below) — given main's table offsets and the now-known body
+        //      length, compute bootstrap size, then call gen_table_bytecode to fill
+        //      __tablestart placeholders and emit constructor-only tables into the deployment tail.
+        //   3. Concatenate [ctor_body][bootstrap][main_bytecode][ctor_only_tables][args].
         let inputs = self.get_constructor_args();
-        let ((constructor_bytecode, constructor_source_map), has_custom_bootstrap) =
-            match Codegen::generate_constructor_bytecode_with_sourcemap(
-                self.evm_version,
-                &contract,
-                self.alternative_constructor.clone(),
-                self.relax_jumps,
-            ) {
-                Ok(result) => result,
-                Err(mut e) => {
-                    // Return any errors except if the inputs is empty and the constructor
-                    // definition is missing
-                    if e.kind != CodegenErrorKind::MissingMacroDefinition("CONSTRUCTOR".to_string()) || !inputs.is_empty() {
-                        // Add File Source to Span
-                        let mut errs = e
-                            .span
-                            .0
-                            .into_iter()
-                            .map(|mut s| {
-                                if s.file.is_none() {
-                                    s.file = Some(Arc::clone(&file));
-                                }
-                                s
-                            })
-                            .collect::<Vec<Span>>();
-                        errs.dedup();
-                        e.span = AstSpan(errs).boxed();
-                        tracing::error!(target: "codegen", "Constructor inputs provided, but contract missing \"CONSTRUCTOR\" macro!");
-                        return Err(CompilerError::CodegenError(e));
-                    }
-
-                    // If the kind is a missing constructor we can ignore it
-                    tracing::warn!(target: "codegen", "Contract has no \"CONSTRUCTOR\" macro definition!");
-                    ((String::default(), Vec::new()), false)
+        let (constructor, contract_for_churn) = match Codegen::generate_constructor_macro_bytecode(
+            self.evm_version,
+            &contract,
+            self.alternative_constructor.clone(),
+            self.relax_jumps,
+        ) {
+            Ok((ctor, updated_contract)) => (Some(ctor), updated_contract),
+            Err(mut e) => {
+                // Return any errors except if the inputs is empty and the constructor
+                // definition is missing
+                if e.kind != CodegenErrorKind::MissingMacroDefinition("CONSTRUCTOR".to_string()) || !inputs.is_empty() {
+                    // Add File Source to Span
+                    let mut errs = e
+                        .span
+                        .0
+                        .into_iter()
+                        .map(|mut s| {
+                            if s.file.is_none() {
+                                s.file = Some(Arc::clone(&file));
+                            }
+                            s
+                        })
+                        .collect::<Vec<Span>>();
+                    errs.dedup();
+                    e.span = AstSpan(errs).boxed();
+                    tracing::error!(target: "codegen", "Constructor inputs provided, but contract missing \"CONSTRUCTOR\" macro!");
+                    return Err(CompilerError::CodegenError(e));
                 }
-            };
-        tracing::info!(target: "core", "CONSTRUCTOR BYTECODE GENERATED [{}]", constructor_bytecode);
+
+                // If the kind is a missing constructor we can ignore it
+                tracing::warn!(target: "codegen", "Contract has no \"CONSTRUCTOR\" macro definition!");
+                // Still need an updated contract for churn (table sizes populated).
+                let updated_contract = Codegen::update_table_size(self.evm_version, &contract).map_err(CompilerError::CodegenError)?;
+                (None, updated_contract)
+            }
+        };
 
         // Encode Constructor Arguments
         let encoded_inputs = Codegen::encode_constructor_args(inputs);
         tracing::info!(target: "core", "ENCODED {} INPUTS", encoded_inputs.len());
 
         // Generate Artifact with ABI
-        let churn_res = cg.churn(
-            file,
-            encoded_inputs,
-            &main_bytecode,
-            &constructor_bytecode,
-            has_custom_bootstrap,
-            Some(main_source_map),
-            Some(constructor_source_map),
-            self.no_size_limit,
-        );
+        let churn_res = cg.assemble_artifact(file, &contract_for_churn, encoded_inputs, main, constructor, self.no_size_limit);
         match churn_res {
             Ok(mut artifact) => {
                 // Then we can have the code gen output the artifact

--- a/crates/core/tests/builtins.rs
+++ b/crates/core/tests/builtins.rs
@@ -96,10 +96,12 @@ fn test_dyn_constructor_arg_builtin() {
         false,
     );
 
+    // CODECOPY source offset for the first dynamic arg is its absolute position in deployment
+    // bytecode: ctor_body_len (0) + bootstrap_size (9) + main_len (17) = 26 = 0x1a.
     assert_eq!(
         final_bytecode.unwrap().bytecode,
         String::from(
-            "60118060093d393df3610007610020526100076100116100403974657374696e6700000000000000000000000000000000000000000000000000"
+            "60118060093d393df36100076100205261000761001a6100403974657374696e6700000000000000000000000000000000000000000000000000"
         )
     );
 }

--- a/crates/core/tests/common.rs
+++ b/crates/core/tests/common.rs
@@ -5,8 +5,10 @@ use huff_neo_lexer::*;
 use huff_neo_parser::*;
 use huff_neo_utils::error::{CodegenError, CodegenErrorKind};
 use huff_neo_utils::evm_version::EVMVersion;
+use huff_neo_utils::file::file_source::FileSource;
 use huff_neo_utils::file::full_file_source::FullFileSource;
 use huff_neo_utils::prelude::*;
+use std::sync::Arc;
 
 /// Compile a Huff source string and return the main bytecode
 pub fn compile_to_bytecode(source: &str) -> Result<String, CodegenError> {
@@ -28,6 +30,28 @@ pub fn compile_to_constructor_bytecode(source: &str) -> Result<(String, bool), C
     let mut contract = parser.parse().unwrap();
     contract.derive_storage_pointers();
     Codegen::generate_constructor_bytecode(&EVMVersion::default(), &contract, None, false)
+}
+
+/// Compile a Huff source string and return the full deployment artifact (constructor body +
+/// bootstrap + main + constructor-only tables + args).
+pub fn compile_to_deployment(source: &str) -> String {
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let evm = &EVMVersion::default();
+    let main = Codegen::generate_main_bytecode_with_sourcemap(evm, &contract, None, false).unwrap();
+    let (constructor, updated_contract) = match Codegen::generate_constructor_macro_bytecode(evm, &contract, None, false) {
+        Ok((ctor, updated)) => (Some(ctor), updated),
+        Err(_) => (None, Codegen::update_table_size(evm, &contract).unwrap()),
+    };
+
+    let mut cg = Codegen::new();
+    let artifact = cg.assemble_artifact(Arc::new(FileSource::default()), &updated_contract, vec![], main, constructor, false).unwrap();
+    artifact.bytecode
 }
 
 /// Compile a Huff source and assert it produces an error of the expected kind

--- a/crates/core/tests/jump_table.rs
+++ b/crates/core/tests/jump_table.rs
@@ -2,8 +2,13 @@ use huff_neo_codegen::Codegen;
 use huff_neo_lexer::Lexer;
 use huff_neo_parser::Parser;
 use huff_neo_utils::evm_version::EVMVersion;
+use huff_neo_utils::file::file_source::FileSource;
 use huff_neo_utils::file::full_file_source::FullFileSource;
 use huff_neo_utils::prelude::Token;
+use std::sync::Arc;
+
+mod common;
+use common::compile_to_deployment;
 
 #[test]
 fn test_tablestart_builtin() {
@@ -278,4 +283,225 @@ fn test_label_clashing() {
             "60086100455f39608061004d5f395f3560e01c8063a9059cbb1461001e575b60208703516202ffe016806020015b60206020015b60206020015b60206020015b6020602001002d00330039003f000000000000000000000000000000000000000000000000000000000000002d00000000000000000000000000000000000000000000000000000000000000330000000000000000000000000000000000000000000000000000000000000039000000000000000000000000000000000000000000000000000000000000003f"
         )
     );
+}
+
+/// Invariant: a code table referenced from the CONSTRUCTOR must not be inserted between the
+/// constructor body and the auto-generated bootstrap. If it is, execution falls into the table
+/// bytes (INVALID opcode) before the bootstrap can run and deployment fails. The table belongs
+/// in the deployment tail, past `MAIN`.
+#[test]
+fn test_constructor_table_does_not_break_auto_bootstrap() {
+    let source = r#"
+        #define macro CONSTRUCTOR() = { __tablestart(TABLE) pop }
+        #define macro MAIN() = {}
+        #define table TABLE { 0xfefe }
+    "#;
+    let bytecode = compile_to_deployment(source);
+
+    // Expected layout: [ctor_body (4)][bootstrap (9)][main (0)][table (2)]
+    //   61 000d                  PUSH2 0x000d   (tablestart resolves to byte 13)
+    //   50                       POP
+    //   60 00 80 60 0d 3d 39 3d f3   bootstrap (9 bytes)
+    //   fe fe                    table data at byte 13
+    assert_eq!(bytecode, "61000d50600080600d3d393df3fefe");
+}
+
+/// CONSTRUCTOR uses `__tablestart` with a non-trivial MAIN. The constructor-only table sits past
+/// main in the deployment tail; the deployed runtime equals exactly MAIN's bytecode (the table is
+/// not part of runtime).
+#[test]
+fn test_constructor_table_with_nontrivial_main() {
+    let source = r#"
+        #define macro CONSTRUCTOR() = { __tablestart(TABLE) pop }
+        #define macro MAIN() = { 0x01 0x02 add }
+        #define table TABLE { 0xdead }
+    "#;
+    let evm = &EVMVersion::default();
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let main = Codegen::generate_main_bytecode_with_sourcemap(evm, &contract, None, false).unwrap();
+    let main_len = main.bytecode.len() / 2;
+    let (constructor, updated_contract) = Codegen::generate_constructor_macro_bytecode(evm, &contract, None, false).unwrap();
+
+    let mut cg = Codegen::new();
+    let artifact =
+        cg.assemble_artifact(Arc::new(FileSource::default()), &updated_contract, vec![], main.clone(), Some(constructor), false).unwrap();
+
+    // Runtime is exactly MAIN bytecode — table is not deployed.
+    assert_eq!(artifact.runtime, main.bytecode.to_lowercase());
+
+    // Tablestart in constructor points at ctor_body_len + bootstrap_size + main_len.
+    // ctor_body_len = 4, bootstrap_size = 9 (PUSH1 main_len, PUSH1 runtime_offset both fit), main_len = 5.
+    let expected_table_offset = 4 + 9 + main_len;
+    assert_eq!(expected_table_offset, 18);
+    let tablestart_value = u16::from_str_radix(&artifact.bytecode[2..6], 16).unwrap() as usize;
+    assert_eq!(tablestart_value, expected_table_offset);
+
+    // Table bytes "dead" are the last 4 hex chars of the deployment bytecode.
+    assert!(artifact.bytecode.ends_with("dead"));
+}
+
+/// When the combined `ctor_body + bootstrap` crosses 0xff, the runtime offset push in the
+/// bootstrap must grow from PUSH1 to PUSH2 and `bootstrap_code_size` must account for the extra
+/// byte. Exercise that branch by padding the constructor body to push the runtime offset above 255.
+#[test]
+fn test_constructor_table_offset_exceeds_one_byte() {
+    // 256 bytes of constructor body (256 JUMPDESTs) ensures bootstrap_size + ctor_body_len > 0xff
+    // so the runtime offset has to be PUSH2.
+    let mut body = String::new();
+    for _ in 0..256 {
+        body.push_str("jumpdest "); // 1 byte each, safe filler.
+    }
+    let source = format!(
+        r#"
+        #define macro CONSTRUCTOR() = {{
+            __tablestart(TABLE) pop
+            {body}
+        }}
+        #define macro MAIN() = {{}}
+        #define table TABLE {{ 0xfefe }}
+    "#
+    );
+    let bytecode = compile_to_deployment(&source);
+
+    // ctor_body_len = 4 (tablestart push2 + pop + nothing) + 256 (filler) = 260.
+    // Runtime offset = bootstrap_size + ctor_body_len = 10 + 260 = 270 = 0x010e (needs PUSH2).
+    // bootstrap layout: PUSH1 size, DUP1, PUSH2 offset, RETURNDATASIZE, CODECOPY, RETURNDATASIZE, RETURN = 10 bytes.
+    // Bootstrap starts at offset 260; the PUSH2 immediate at offset 260+3 = 263 holds 0x010e.
+    // Verify the table sits at offset 270 (after bootstrap end).
+    let table_offset_in_bytecode = 270;
+    let expected_table_hex = format!("{:02x}", table_offset_in_bytecode);
+    // tablestart PUSH2 immediate is at bytes 1-2 (chars 2-6) of the bytecode.
+    let tablestart = u16::from_str_radix(&bytecode[2..6], 16).unwrap();
+    assert_eq!(tablestart as usize, table_offset_in_bytecode, "tablestart should resolve past bootstrap");
+    assert!(bytecode.ends_with("fefe"), "table bytes appear at the deployment tail");
+    let _ = expected_table_hex; // kept for clarity of intent
+}
+
+/// When the same table is referenced from both CONSTRUCTOR and MAIN, it is emitted exactly once
+/// (in the runtime section). The constructor's `__tablestart` resolves into that shared copy at
+/// `bootstrap_size + ctor_body_len + main_body_len + offset_within_runtime`.
+#[test]
+fn test_table_shared_between_constructor_and_main_emitted_once() {
+    let source = r#"
+        #define macro CONSTRUCTOR() = { __tablestart(SHARED) pop }
+        #define macro MAIN() = { __tablestart(SHARED) pop }
+        #define table SHARED { 0xcafe }
+    "#;
+    let evm = &EVMVersion::default();
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let main = Codegen::generate_main_bytecode_with_sourcemap(evm, &contract, None, false).unwrap();
+    let main_body_len = main.body_len();
+    let shared_offset_in_main = *main.table_offsets.get("SHARED").expect("SHARED table emitted in main");
+    let (constructor, updated_contract) = Codegen::generate_constructor_macro_bytecode(evm, &contract, None, false).unwrap();
+    let ctor_body_len: usize = constructor.bytecode_res.bytes.iter().map(|s| s.bytes.len()).sum();
+
+    let mut cg = Codegen::new();
+    let artifact =
+        cg.assemble_artifact(Arc::new(FileSource::default()), &updated_contract, vec![], main, Some(constructor), false).unwrap();
+
+    // The table bytes ("cafe") appear exactly once in the deployment bytecode.
+    let occurrences = artifact.bytecode.matches("cafe").count();
+    assert_eq!(occurrences, 1, "shared table must be emitted only once");
+
+    // Constructor's __tablestart resolves into the runtime-resident copy.
+    // bootstrap_size: contract_length = main_body_len + 2 (table); both <256 → bootstrap_size = 9.
+    let bootstrap_size = 9;
+    let ctor_tablestart_expected = bootstrap_size + ctor_body_len + shared_offset_in_main;
+    let ctor_tablestart = u16::from_str_radix(&artifact.bytecode[2..6], 16).unwrap() as usize;
+    assert_eq!(ctor_tablestart, ctor_tablestart_expected);
+
+    // Main's __tablestart resolves to the table offset within the runtime. The runtime starts at
+    // deployment offset ctor_body_len + bootstrap_size in the deployment bytecode. The main
+    // tablestart PUSH2 immediate lives at the start of the main body.
+    let main_start_in_deployment = ctor_body_len + bootstrap_size;
+    let main_tablestart_chars = &artifact.bytecode[(main_start_in_deployment + 1) * 2..(main_start_in_deployment + 3) * 2];
+    let main_tablestart = u16::from_str_radix(main_tablestart_chars, 16).unwrap() as usize;
+    // shared_offset_in_main already equals body_len + offset-into-tables, since gen_table_bytecode
+    // stores the absolute (within-runtime) offset directly.
+    assert_eq!(main_tablestart, shared_offset_in_main);
+    assert!(main_tablestart >= main_body_len, "table sits after the runtime body");
+}
+
+/// CONSTRUCTOR-only and MAIN-only tables coexist: the ctor-only table is appended past main in the
+/// deployment tail and never enters runtime; the main-only table sits in runtime as usual.
+#[test]
+fn test_constructor_only_and_main_only_tables_coexist() {
+    let source = r#"
+        #define macro CONSTRUCTOR() = { __tablestart(CTOR_ONLY) pop }
+        #define macro MAIN() = { __tablestart(MAIN_ONLY) pop }
+        #define table CTOR_ONLY { 0xaaaa }
+        #define table MAIN_ONLY { 0xbbbb }
+    "#;
+    let evm = &EVMVersion::default();
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let main = Codegen::generate_main_bytecode_with_sourcemap(evm, &contract, None, false).unwrap();
+    let (constructor, updated_contract) = Codegen::generate_constructor_macro_bytecode(evm, &contract, None, false).unwrap();
+
+    let mut cg = Codegen::new();
+    let artifact =
+        cg.assemble_artifact(Arc::new(FileSource::default()), &updated_contract, vec![], main.clone(), Some(constructor), false).unwrap();
+
+    // CTOR_ONLY table only appears in deployment, never in runtime.
+    assert!(artifact.bytecode.contains("aaaa"));
+    assert!(!artifact.runtime.contains("aaaa"));
+
+    // MAIN_ONLY table appears in both deployment and runtime.
+    assert!(artifact.runtime.contains("bbbb"));
+    assert_eq!(artifact.bytecode.matches("bbbb").count(), 1);
+
+    // CTOR_ONLY is at the very end of deployment (past constructor_args, which are empty here).
+    assert!(artifact.bytecode.ends_with("aaaa"));
+}
+
+/// `relax_jumps` shrinks JUMP/JUMPI placeholders but must not touch `__tablestart` placeholders
+/// (which are always PUSH2). Verify the layout invariants still hold when relaxation is enabled.
+#[test]
+fn test_constructor_table_with_relax_jumps() {
+    let source = r#"
+        #define macro CONSTRUCTOR() = {
+            __tablestart(TABLE) pop
+            target jump
+            target:
+        }
+        #define macro MAIN() = {}
+        #define table TABLE { 0xfefe }
+    "#;
+    let evm = &EVMVersion::default();
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // relax_jumps = true.
+    let main = Codegen::generate_main_bytecode_with_sourcemap(evm, &contract, None, true).unwrap();
+    let (constructor, updated_contract) = Codegen::generate_constructor_macro_bytecode(evm, &contract, None, true).unwrap();
+
+    let mut cg = Codegen::new();
+    let artifact =
+        cg.assemble_artifact(Arc::new(FileSource::default()), &updated_contract, vec![], main, Some(constructor), false).unwrap();
+
+    // Table bytes still sit at the very end of deployment (past the bootstrap).
+    assert!(artifact.bytecode.ends_with("fefe"));
+    // tablestart placeholder is still PUSH2 (always), so the bytecode starts with `61` (PUSH2 opcode).
+    assert!(artifact.bytecode.starts_with("61"));
 }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1381,15 +1381,13 @@ impl Parser {
                 if !on_type {
                     // Check for reserved primitive type keyword use and throw an error if so
                     match self.current_token.kind.clone() {
-                        TokenKind::Ident(arg_str) => {
-                            if PrimitiveEVMType::try_from(&arg_str).is_ok() {
-                                return Err(ParserError {
-                                    kind: ParserErrorKind::InvalidTypeAsArgumentName(self.current_token.kind.clone()),
-                                    hint: Some(format!("Argument names cannot be EVM types: {arg_str}")),
-                                    spans: AstSpan(vec![self.current_token.span.clone()]),
-                                    cursor: self.cursor,
-                                });
-                            }
+                        TokenKind::Ident(arg_str) if PrimitiveEVMType::try_from(&arg_str).is_ok() => {
+                            return Err(ParserError {
+                                kind: ParserErrorKind::InvalidTypeAsArgumentName(self.current_token.kind.clone()),
+                                hint: Some(format!("Argument names cannot be EVM types: {arg_str}")),
+                                spans: AstSpan(vec![self.current_token.span.clone()]),
+                                cursor: self.cursor,
+                            });
                         }
                         TokenKind::PrimitiveType(ty) => {
                             return Err(ParserError {

--- a/crates/test-runner/src/runner.rs
+++ b/crates/test-runner/src/runner.rs
@@ -268,9 +268,12 @@ impl TestRunner {
         let res = Codegen::macro_to_bytecode(&evm_version, m, &contract, &mut scope_mgr, 0, false, None, false)
             .map_err(|e| RunnerError::CompilerError(CompilerError::CodegenError(e)))?;
 
-        // Generate table bytecode for compiled test macro
-        let (bytecode, source_map) =
-            Codegen::gen_table_bytecode(&contract, res).map_err(|e| RunnerError::CompilerError(CompilerError::CodegenError(e)))?;
+        // Generate table bytecode for compiled test macro. Test macros run standalone (no
+        // bootstrap, no upstream dedup target), so base_offset = 0 and the external map is empty.
+        let table_out = Codegen::gen_table_bytecode(&contract, res, 0, &std::collections::HashMap::new())
+            .map_err(|e| RunnerError::CompilerError(CompilerError::CodegenError(e)))?;
+        let bytecode = format!("{}{}", table_out.body, table_out.tables);
+        let source_map = table_out.source_map;
 
         // Deploy compiled test macro
         let address = match self.target_address {

--- a/deny.toml
+++ b/deny.toml
@@ -30,16 +30,38 @@ name = "ring"
 
 [advisories]
 ignore = [
-  # protobuf may crash due to uncontrolled recursion - https://rustsec.org/advisories/RUSTSEC-2024-0437
-  "RUSTSEC-2024-0437",
-  # paste is unmaintained - hhttps://rustsec.org/advisories/RUSTSEC-2024-0436
+  # paste is unmaintained - https://rustsec.org/advisories/RUSTSEC-2024-0436
   "RUSTSEC-2024-0436",
-  # number_prefix is unmaintained - https://rustsec.org/advisories/RUSTSEC-2025-0119
-  "RUSTSEC-2025-0119",
   # unsoundness of safe `reciprocal_mg10` - https://rustsec.org/advisories/RUSTSEC-2025-0137
   "RUSTSEC-2025-0137",
-  # `IterMut` violates Stacked Borrows - https://rustsec.org/advisories/RUSTSEC-2026-0002
-  "RUSTSEC-2026-0002",
+  # bytes: integer overflow in `BytesMut::reserve` - https://rustsec.org/advisories/RUSTSEC-2026-0007
+  "RUSTSEC-2026-0007",
+  # bytes: potential undefined behavior when dereferencing Buf struct - https://rustsec.org/advisories/RUSTSEC-2026-0008
+  "RUSTSEC-2026-0008",
+  # chrono: RFC 2822 parsing DoS - https://rustsec.org/advisories/RUSTSEC-2026-0009
+  "RUSTSEC-2026-0009",
+  # keccak ARMv8 backend unsoundness - https://rustsec.org/advisories/RUSTSEC-2026-0012
+  "RUSTSEC-2026-0012",
+  # aws-lc CN validation logic error - https://rustsec.org/advisories/RUSTSEC-2026-0044
+  "RUSTSEC-2026-0044",
+  # aws-lc AES-CCM tag verification timing side channel - https://rustsec.org/advisories/RUSTSEC-2026-0045
+  "RUSTSEC-2026-0045",
+  # aws-lc PKCS7_verify certificate chain validation bypass - https://rustsec.org/advisories/RUSTSEC-2026-0046
+  "RUSTSEC-2026-0046",
+  # aws-lc PKCS7_verify signature validation bypass - https://rustsec.org/advisories/RUSTSEC-2026-0047
+  "RUSTSEC-2026-0047",
+  # aws-lc CRL distribution point scope check logic error - https://rustsec.org/advisories/RUSTSEC-2026-0048
+  "RUSTSEC-2026-0048",
+  # webpki/rustls CRL distribution-point matching logic - https://rustsec.org/advisories/RUSTSEC-2026-0049
+  "RUSTSEC-2026-0049",
+  # rand is unsound with a custom logger - https://rustsec.org/advisories/RUSTSEC-2026-0097
+  "RUSTSEC-2026-0097",
+  # webpki URI name constraints accepted incorrectly - https://rustsec.org/advisories/RUSTSEC-2026-0098
+  "RUSTSEC-2026-0098",
+  # webpki wildcard DNS name constraint logic - https://rustsec.org/advisories/RUSTSEC-2026-0099
+  "RUSTSEC-2026-0099",
+  # webpki CRL `onlySomeReasons` parsing panic - https://rustsec.org/advisories/RUSTSEC-2026-0104
+  "RUSTSEC-2026-0104",
 ]
 yanked = "warn"
 
@@ -47,4 +69,4 @@ yanked = "warn"
 multiple-versions = "allow"
 
 [sources]
-allow-git = ["https://github.com/foundry-rs/foundry", "https://github.com/paradigmxyz/solar"]
+allow-git = ["https://github.com/foundry-rs/foundry", "https://github.com/paradigmxyz/solar", "https://github.com/tempoxyz/tempo"]


### PR DESCRIPTION
This fixes 163:
- Fixed `__tablestart` in `CONSTRUCTOR` corrupting the auto-bootstrap: constructor-only tables now sit past `main` in the deployment tail instead of between the body and bootstrap.
- Tables referenced by both `CONSTRUCTOR` and `MAIN` are emitted once (in the runtime); the constructor's `__tablestart` resolves into that shared copy.
- Split constructor codegen into a macro-expansion phase plus a finalization phase inside `assemble_artifact`, so table offsets are resolved with full knowledge of bootstrap size and
  main layout.