### PR TITLE
fix(cli): error on --bin-runtime when CONSTRUCTOR returns custom bytecode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+- `hnc --bin-runtime` (`-r`) now errors when the contract's `CONSTRUCTOR` returns its own bytecode,
+  instead of silently emitting `MAIN`, which would not match the deployed runtime. Constructors
+  that only initialize state (no `RETURN`) are unaffected.
 
 ## [1.5.15] - 2026-05-24
 - Update to foundry v1.7.1.

--- a/bin/hnc/src/arguments/base.rs
+++ b/bin/hnc/src/arguments/base.rs
@@ -53,7 +53,7 @@ pub struct HuffArgs {
     #[clap(short = 'b', long = "bytecode")]
     pub bytecode: bool,
 
-    /// Generate and log runtime bytecode.
+    /// Generate and log runtime bytecode. Errors if CONSTRUCTOR returns custom bytes (runtime ≠ MAIN).
     #[clap(short = 'r', long = "bin-runtime")]
     pub bin_runtime: bool,
 

--- a/bin/hnc/src/main.rs
+++ b/bin/hnc/src/main.rs
@@ -433,6 +433,16 @@ fn main() {
     }
 
     if cli.bin_runtime {
+        if let Some(a) = artifacts.iter().find(|a| a.has_custom_bootstrap) {
+            eprintln!(
+                "{}",
+                Paint::red(&format!(
+                    "Cannot emit runtime bytecode for \"{}\": the contract defines a CONSTRUCTOR that returns its own bytecode, so the deployed runtime is determined at deployment time and not statically equal to the compiled MAIN macro. Use --bytecode (-b) to emit the creation bytecode instead.",
+                    a.file.path
+                ))
+            );
+            exit(1);
+        }
         match sources.len() {
             1 => {
                 if cli.bytecode {

--- a/bin/hnc/tests/cli.rs
+++ b/bin/hnc/tests/cli.rs
@@ -59,3 +59,85 @@ fn bytecode_overrides_constant_invalid() {
 
     tmp.close().unwrap();
 }
+
+#[test]
+fn bin_runtime_errors_when_constructor_returns_custom_bytecode() {
+    let mut cmd = cargo_bin_cmd!("hnc");
+    let tmp = assert_fs::TempDir::new().unwrap();
+    let file = tmp.child("code.huff");
+    file.write_str(
+        r#"
+#define macro CONSTRUCTOR() = {
+    0x0 0x0 return
+}
+
+#define macro MAIN() = {
+    __VERBATIM(0xff)
+}
+"#,
+    )
+    .unwrap();
+
+    cmd.current_dir(&tmp)
+        .args(["code.huff", "--bin-runtime"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("CONSTRUCTOR").and(predicate::str::contains("--bytecode")));
+
+    tmp.close().unwrap();
+}
+
+#[test]
+fn bin_runtime_succeeds_with_state_init_constructor() {
+    let mut cmd = cargo_bin_cmd!("hnc");
+    let tmp = assert_fs::TempDir::new().unwrap();
+    let file = tmp.child("code.huff");
+    file.write_str(
+        r#"
+#define constant OWNER = 0x0
+
+#define macro CONSTRUCTOR() = {
+    caller [OWNER] sstore
+}
+
+#define macro MAIN() = {
+    __VERBATIM(0xff)
+}
+"#,
+    )
+    .unwrap();
+
+    cmd.current_dir(&tmp)
+        .args(["code.huff", "--bin-runtime"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"^ff$").unwrap())
+        .stderr(predicate::str::is_empty());
+
+    tmp.close().unwrap();
+}
+
+#[test]
+fn bin_runtime_succeeds_without_constructor() {
+    let mut cmd = cargo_bin_cmd!("hnc");
+    let tmp = assert_fs::TempDir::new().unwrap();
+    let file = tmp.child("code.huff");
+    file.write_str(
+        r#"
+#define macro MAIN() = {
+    __VERBATIM(0xff)
+}
+"#,
+    )
+    .unwrap();
+
+    cmd.current_dir(&tmp)
+        .args(["code.huff", "--bin-runtime"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"^ff$").unwrap())
+        .stderr(predicate::str::is_empty());
+
+    tmp.close().unwrap();
+}

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -1439,6 +1439,7 @@ impl Codegen {
 
         artifact.bytecode = format!("{constructor_body}{bootstrap_code}{main_bytecode}{ctor_only_tables}{constructor_args}").to_lowercase();
         artifact.runtime = main_bytecode.to_lowercase();
+        artifact.has_custom_bootstrap = has_custom_bootstrap;
         artifact.file = file;
 
         // Set source maps if provided

--- a/crates/utils/src/artifact.rs
+++ b/crates/utils/src/artifact.rs
@@ -106,6 +106,11 @@ pub struct Artifact {
     pub constructor_map: Option<Vec<SourceMapEntry>>,
     /// Source map for runtime
     pub runtime_map: Option<Vec<SourceMapEntry>>,
+    /// True when the user's CONSTRUCTOR returns its own bytecode, suppressing the auto-bootstrap.
+    /// In that case the deployed runtime is whatever the constructor returns and is not
+    /// statically known to equal the compiled MAIN macro.
+    #[serde(default)]
+    pub has_custom_bootstrap: bool,
 }
 
 impl Artifact {


### PR DESCRIPTION
Fixes #167

- `hnc --bin-runtime` (`-r`) now errors when the contract's `CONSTRUCTOR` returns its own bytecode, instead of silently emitting `MAIN`, which would not match the deployed runtime. Constructors that only initialize state (no `RETURN`) are unaffected.