### PR TITLE
feat(codegen): add __codesize(RUNTIME) for compile-time runtime size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 - `hnc --bin-runtime` (`-r`) now errors when the contract's `CONSTRUCTOR` returns its own bytecode,
   instead of silently emitting `MAIN`, which would not match the deployed runtime. Constructors
   that only initialize state (no `RETURN`) are unaffected.
+- Add `__codesize(RUNTIME)`: resolves at compile time to the byte length of the runtime section
+  (MAIN body + appended runtime tables). Usable in bothmake pre-releaseCONSTRUCTOR (directly or via a
+  derived `#define constant`). The self-referential MAIN-side case converges via iterative MAIN
+  codegen, bounded by EIP-170 (at most PUSH2). Enables Solidity-style immutables that the
+  runtime reads at compile-time literal offsets, with no runtime `codesize` arithmetic. Not
+  allowed inside code tables (would create a circular sizing dependency). `RUNTIME` is reserved
+  as a macro name.
 
 ## [1.5.15] - 2026-05-24
 - Update to foundry v1.7.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   instead of silently emitting `MAIN`, which would not match the deployed runtime. Constructors
   that only initialize state (no `RETURN`) are unaffected.
 - Add `__codesize(RUNTIME)`: resolves at compile time to the byte length of the runtime section
-  (MAIN body + appended runtime tables). Usable in bothmake pre-releaseCONSTRUCTOR (directly or via a
+  (MAIN body + appended runtime tables). Usable in both MAIN and CONSTRUCTOR (directly or via a
   derived `#define constant`). The self-referential MAIN-side case converges via iterative MAIN
   codegen, bounded by EIP-170 (at most PUSH2). Enables Solidity-style immutables that the
   runtime reads at compile-time literal offsets, with no runtime `codesize` arithmetic. Not

--- a/book/huff-language/builtin-functions.md
+++ b/book/huff-language/builtin-functions.md
@@ -35,6 +35,39 @@ __RIGHTPAD(0x123)
 ### `__codesize(<macro>|<function>)`
 Pushes the code size of the macro or function passed to the stack.
 
+#### `__codesize(RUNTIME)`
+`RUNTIME` is a reserved argument that resolves at compile time to the byte length of the runtime section as the compiler emits it — `MAIN`'s body plus its appended runtime tables. Usable in both `MAIN` and `CONSTRUCTOR` (directly or via a derived `#define constant`).
+
+The runtime size is self-referential when used from `MAIN` (the embedded value contributes to the size it measures). The compiler resolves this by iterating `MAIN` codegen to a fixed point — typically converges in 2–3 passes. EIP-170 bounds the value at PUSH2, so widths never grow beyond two bytes.
+
+Not allowed inside a code table — code tables contribute to the runtime size, so embedding the runtime size inside one would create a circular dependency in table sizing. `RUNTIME` is also reserved as a macro name; `#define macro RUNTIME() = { ... }` is rejected.
+
+This enables Solidity-style immutables without on-chain arithmetic. `CONSTRUCTOR` copies `MAIN` to memory, writes immutable values past it, and returns the combined region. `MAIN` reads each immutable at a compile-time literal offset:
+
+```javascript
+#define constant IMMUTABLE_1 = __codesize(RUNTIME)
+#define constant IMMUTABLE_2 = [IMMUTABLE_1] + 0x20
+#define constant RETURN_LEN  = [IMMUTABLE_2] + 0x20
+
+#define macro CONSTRUCTOR() = {
+    // Copy MAIN to memory at offset 0.
+    [IMMUTABLE_1] __codesize(CONSTRUCTOR) 0x00 codecopy
+
+    // Append two immutables past it.
+    0x11 [IMMUTABLE_1] mstore
+    0x22 [IMMUTABLE_2] mstore
+
+    // Return runtime + immutables.
+    [RETURN_LEN] 0x00 return
+}
+
+#define macro MAIN() = {
+    // Read the second immutable at a compile-time literal offset.
+    0x20 [IMMUTABLE_2] 0x00 codecopy
+    0x20 0x00 return
+}
+```
+
 ### `__tablestart(<table>)` and `__tablesize(<table>)`
 These functions related to Jump Tables are described in the next section.
 

--- a/crates/codegen/README.md
+++ b/crates/codegen/README.md
@@ -103,6 +103,7 @@ fn example() {
       events: vec![],
       tables: vec![],
       labels: HashSet::new(),
+      runtime_size: None,
     };
     
     // Generate the main bytecode
@@ -166,6 +167,7 @@ fn example() {
         events: vec![],
         tables: vec![],
         labels: HashSet::new(),
+        runtime_size: None,
     };
 
     // Generate the constructor bytecode

--- a/crates/codegen/src/irgen/builtin_function.rs
+++ b/crates/codegen/src/irgen/builtin_function.rs
@@ -1,6 +1,7 @@
 use crate::Codegen;
 use crate::irgen::constants::{constant_gen, evaluate_constant_value, lookup_constant};
-use alloy_primitives::{B256, hex, keccak256};
+use alloy_primitives::{B256, U256, hex, keccak256};
+use huff_neo_utils::ast::huff::RUNTIME_CODESIZE_ARG;
 use huff_neo_utils::builtin_eval::{PadDirection, eval_builtin_bytes, eval_event_hash, eval_function_signature};
 use huff_neo_utils::bytecode::{
     AssertPcPlaceholderData, BytecodeRes, BytecodeSegments, Bytes, CircularCodeSizeIndices, CircularCodesizePlaceholderData,
@@ -458,6 +459,21 @@ fn codesize<'a>(
             return Err(invalid_arguments_error("Expected identifier as argument to __codesize", &bf.span));
         }
     };
+
+    // Magic argument: RUNTIME resolves to the byte length of the runtime section
+    // (MAIN body + appended runtime tables). MAIN-side use converges via iterative MAIN
+    // codegen; constructor-side use sees the converged value.
+    if macro_name == RUNTIME_CODESIZE_ARG {
+        let size = contract.runtime_size.ok_or_else(|| CodegenError {
+            kind: CodegenErrorKind::RuntimeSizeNotComputed,
+            span: bf.span.clone_box(),
+            token: None,
+        })?;
+        let push_value = PushValue::from(U256::from(size).to_be_bytes::<32>());
+        let push_bytes = push_value.to_hex_with_opcode(evm_version);
+        let offset = push_bytes.len() / 2;
+        return Ok((offset, Bytes::Raw(push_bytes)));
+    }
 
     let ir_macro = if let Some(m) = contract.find_macro_by_name(macro_name) {
         m

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -4,9 +4,10 @@
 #![forbid(unsafe_code)]
 
 use crate::irgen::builtin_function::builtin_pad;
-use alloy_primitives::hex;
+use alloy_primitives::{U256, hex};
 use huff_neo_utils::ast::huff::*;
 use huff_neo_utils::ast::span::AstSpan;
+use huff_neo_utils::builtin_eval::{PadDirection, eval_builtin_bytes, eval_event_hash, eval_function_signature};
 use huff_neo_utils::bytes_util::str_to_bytes32;
 use huff_neo_utils::file::file_source::FileSource;
 use huff_neo_utils::scope::ScopeManager;
@@ -37,6 +38,14 @@ pub(crate) const MAX_MACRO_RECURSION_DEPTH: usize = 100;
 /// This limit prevents infinite loops in pathological cases where convergence fails,
 /// though typical contracts converge in a few iterations.
 const JUMP_RELAXATION_MAX_ITERATIONS: usize = 20;
+
+/// Maximum number of MAIN codegen passes used to converge `__codesize(RUNTIME)`.
+///
+/// When MAIN (or a constant referenced by MAIN) uses `__codesize(RUNTIME)`, the runtime size
+/// depends on the embedded value, which depends on the runtime size. Each pass recompiles MAIN
+/// with the previous pass's measured size. PUSH widths only grow (never shrink) across passes,
+/// and EIP-170 caps the value at PUSH2, so convergence is normally 2–3 iterations.
+const MAIN_RUNTIME_SIZE_MAX_ITERATIONS: usize = 10;
 
 /// EIP-170 contract size limit (24576 bytes)
 pub const EIP170_CONTRACT_SIZE_LIMIT: usize = 24576;
@@ -146,6 +155,33 @@ impl Codegen {
     /// `build_artifact` uses the body length and table offsets to dedupe constructor-side
     /// `__tablestart` references into the runtime copy.
     pub fn generate_main_bytecode_with_sourcemap(
+        evm_version: &EVMVersion,
+        contract: &Contract,
+        alternative_main: Option<String>,
+        relax_jumps: bool,
+    ) -> Result<MainBytecodeOutput, CodegenError> {
+        // Iterate to a fixed point on `__codesize(RUNTIME)`. Each pass recompiles MAIN with the
+        // previous pass's measured runtime size. PUSH widths only grow across passes, EIP-170
+        // caps them at PUSH2, so we converge in a handful of iterations.
+        let mut iter_contract = contract.clone();
+        let mut current_size = iter_contract.runtime_size.unwrap_or(0);
+        for _ in 0..MAIN_RUNTIME_SIZE_MAX_ITERATIONS {
+            iter_contract.runtime_size = Some(current_size);
+            let result = Self::generate_main_bytecode_inner(evm_version, &iter_contract, alternative_main.clone(), relax_jumps)?;
+            let new_size = result.bytecode.len() / 2;
+            if new_size == current_size {
+                return Ok(result);
+            }
+            current_size = new_size;
+        }
+        Err(CodegenError {
+            kind: CodegenErrorKind::RuntimeSizeNotConverged(MAIN_RUNTIME_SIZE_MAX_ITERATIONS),
+            span: AstSpan(vec![]).boxed(),
+            token: None,
+        })
+    }
+
+    fn generate_main_bytecode_inner(
         evm_version: &EVMVersion,
         contract: &Contract,
         alternative_main: Option<String>,
@@ -271,13 +307,20 @@ impl Codegen {
     /// Generates bytecode for a builtin function call used for constants, code tables, etc.
     /// Returns a PushValue that can be converted to bytecode with or without opcode
     pub fn gen_builtin_bytecode(contract: &Contract, bf: &BuiltinFunctionCall, span: AstSpan) -> Result<PushValue, CodegenError> {
-        use huff_neo_utils::builtin_eval::{PadDirection, eval_builtin_bytes, eval_event_hash, eval_function_signature};
         match bf.kind {
             BuiltinFunctionKind::FunctionSignature => eval_function_signature(contract, bf),
             BuiltinFunctionKind::Bytes => eval_builtin_bytes(bf),
             BuiltinFunctionKind::EventHash => eval_event_hash(contract, bf),
             BuiltinFunctionKind::LeftPad => builtin_pad(contract, bf, PadDirection::Left),
             BuiltinFunctionKind::RightPad => builtin_pad(contract, bf, PadDirection::Right),
+            _ if is_runtime_codesize(bf) => {
+                let size = contract.runtime_size.ok_or_else(|| CodegenError {
+                    kind: CodegenErrorKind::RuntimeSizeNotComputed,
+                    span: span.clone_box(),
+                    token: None,
+                })?;
+                Ok(PushValue::from(U256::from(size).to_be_bytes::<32>()))
+            }
             _ => Err(CodegenError {
                 kind: CodegenErrorKind::UnsupportedBuiltinFunction(format!("{}", bf.kind)),
                 span: span.boxed(),
@@ -295,6 +338,13 @@ impl Codegen {
                     byte_code = format!("{byte_code}{code}");
                 }
                 StatementType::BuiltinFunctionCall(bf) => {
+                    if is_runtime_codesize(bf) {
+                        return Err(CodegenError {
+                            kind: CodegenErrorKind::CodesizeRuntimeInCodeTable,
+                            span: statement.span.clone_box(),
+                            token: None,
+                        });
+                    }
                     let push_value = Codegen::gen_builtin_bytecode(contract, bf, statement.span.clone())?;
                     // Use full hex for padding functions (always 32 bytes), trimmed for others
                     let hex_data = match bf.kind {

--- a/crates/codegen/tests/abigen.rs
+++ b/crates/codegen/tests/abigen.rs
@@ -34,6 +34,7 @@ fn constructs_valid_abi() {
         flattened_source: None,
         source_files: vec![],
         source_map: vec![],
+        runtime_size: None,
     };
 
     // Generate the abi from the contract
@@ -78,6 +79,7 @@ fn missing_constructor_fails() {
         flattened_source: None,
         source_files: vec![],
         source_map: vec![],
+        runtime_size: None,
     };
 
     // Generate the abi from the contract

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -511,6 +511,10 @@ impl<'a, 'l> Compiler<'a, 'l> {
         };
         tracing::info!(target: "core", "MAIN BYTECODE GENERATED [{}]", main.bytecode);
 
+        // Expose the runtime byte length to constructor codegen so `__codesize(RUNTIME)`
+        // (directly or via a derived constant) resolves.
+        contract.runtime_size = Some(main.bytecode.len() / 2);
+
         // Order of constructor assembly:
         //   1. generate_constructor_macro_bytecode — expand the macro into raw bytes, detect
         //      whether the body contains its own RETURN (custom bootstrap).

--- a/crates/core/tests/codesize_runtime.rs
+++ b/crates/core/tests/codesize_runtime.rs
@@ -1,0 +1,191 @@
+//! Tests for the `__codesize(RUNTIME)` builtin form.
+//!
+//! `__codesize(RUNTIME)` resolves at compile time to the byte length of the runtime section
+//! (MAIN body + appended runtime tables). Usable in both the constructor and MAIN; MAIN
+//! codegen iterates to a fixed point on the self-referential size.
+
+mod common;
+
+use huff_neo_lexer::*;
+use huff_neo_parser::*;
+use huff_neo_utils::file::full_file_source::FullFileSource;
+use huff_neo_utils::prelude::*;
+
+#[test]
+fn runtime_codesize_inline_in_constructor() {
+    // MAIN compiles to 5 bytes (`PUSH1 0x01 PUSH1 0x02 ADD` = `60016002 01`).
+    // The constructor returns its own bytecode (custom bootstrap), so `__codesize(RUNTIME)` is
+    // exposed and resolves to 5. The constant has been padded to PUSH1 by the codegen.
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) { 0x01 0x02 add }
+        #define macro CONSTRUCTOR() = takes(0) returns(0) {
+            __codesize(RUNTIME) pop 0x00 0x00 return
+        }
+    "#;
+
+    let bytecode = common::compile_to_deployment(source);
+    assert_eq!(bytecode, "6005505f5ff36001600201");
+}
+
+#[test]
+fn runtime_codesize_via_constant_wrapper() {
+    let source = r#"
+        #define constant SIZE = __codesize(RUNTIME)
+
+        #define macro MAIN() = takes(0) returns(0) { 0x01 0x02 add }
+        #define macro CONSTRUCTOR() = takes(0) returns(0) {
+            [SIZE] pop 0x00 0x00 return
+        }
+    "#;
+
+    let bytecode = common::compile_to_deployment(source);
+    assert_eq!(bytecode, "6005505f5ff36001600201");
+}
+
+#[test]
+fn runtime_codesize_in_arithmetic_expression() {
+    // 5 + 0x20 = 0x25 (37). Verifies the value flows through constant arithmetic.
+    let source = r#"
+        #define constant SIZE = __codesize(RUNTIME)
+        #define constant SIZE_PLUS = [SIZE] + 0x20
+
+        #define macro MAIN() = takes(0) returns(0) { 0x01 0x02 add }
+        #define macro CONSTRUCTOR() = takes(0) returns(0) {
+            [SIZE_PLUS] pop 0x00 0x00 return
+        }
+    "#;
+
+    let bytecode = common::compile_to_deployment(source);
+    assert!(bytecode.starts_with("6025"), "expected PUSH1 0x25 prefix, got {bytecode}");
+}
+
+#[test]
+fn runtime_codesize_inline_in_main() {
+    // MAIN embeds its own runtime size. Iteration converges: 0 → 2 (PUSH1 + value).
+    // Trial bytecodes: pass 1 with runtime_size=0 emits `60 00 50` (PUSH1 0x00 POP) = 3 bytes.
+    // Pass 2 with runtime_size=3 emits `60 03 50` (PUSH1 0x03 POP) = 3 bytes. Stable.
+    let source = r#"
+        #define macro MAIN() = takes(0) returns(0) { __codesize(RUNTIME) pop }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    assert_eq!(bytecode, "60 03 50".replace(' ', ""));
+}
+
+#[test]
+fn runtime_codesize_via_constant_in_main() {
+    let source = r#"
+        #define constant SIZE = __codesize(RUNTIME)
+        #define macro MAIN() = takes(0) returns(0) { [SIZE] pop }
+    "#;
+
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    assert_eq!(bytecode, "600350");
+}
+
+#[test]
+fn runtime_codesize_arithmetic_in_main() {
+    let source = r#"
+        #define constant SIZE = __codesize(RUNTIME)
+        #define constant SIZE_PLUS = [SIZE] + 0x20
+        #define macro MAIN() = takes(0) returns(0) { [SIZE_PLUS] pop }
+    "#;
+
+    // MAIN = PUSH1 (0x03 + 0x20) POP = `60 23 50`.
+    let bytecode = common::compile_to_bytecode(source).unwrap();
+    assert_eq!(bytecode, "602350");
+}
+
+#[test]
+fn runtime_codesize_used_in_both_main_and_constructor() {
+    // Same constant referenced from both MAIN and CONSTRUCTOR — both PUSHes embed the same
+    // converged runtime size (= MAIN's own length).
+    let source = r#"
+        #define constant SIZE = __codesize(RUNTIME)
+
+        #define macro MAIN() = takes(0) returns(0) { [SIZE] pop }
+        #define macro CONSTRUCTOR() = takes(0) returns(0) {
+            [SIZE] pop 0x00 0x00 return
+        }
+    "#;
+
+    let bytecode = common::compile_to_deployment(source);
+    // Constructor: 60 03 50 5f 5f f3 (PUSH1 0x03 POP PUSH0 PUSH0 RETURN, custom bootstrap)
+    // Main:        60 03 50           (PUSH1 0x03 POP)
+    assert_eq!(bytecode, "6003505f5ff3600350");
+}
+
+#[test]
+fn runtime_codesize_full_immutables_example() {
+    // The program from issue #166: MAIN reads an immutable at a compile-time-resolved offset.
+    let source = r#"
+        #define constant IMMUTABLE_1 = __codesize(RUNTIME)
+        #define constant IMMUTABLE_2 = [IMMUTABLE_1] + 0x20
+        #define constant RETURN_LEN  = [IMMUTABLE_2] + 0x20
+
+        #define macro CONSTRUCTOR() = takes(0) returns(0) {
+            [IMMUTABLE_1] __codesize(CONSTRUCTOR) 0x00 codecopy
+            0x11 [IMMUTABLE_1] mstore
+            0x22 [IMMUTABLE_2] mstore
+            [RETURN_LEN] 0x00 return
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            0x20 [IMMUTABLE_2] 0x00 codecopy
+            0x20 0x00 return
+        }
+    "#;
+
+    // MAIN body: PUSH1 0x20, PUSH1 <IMMUTABLE_2>, PUSH0, CODECOPY, PUSH1 0x20, PUSH0, RETURN
+    // = 10 bytes (PUSH0 used for 0x00 under Shanghai+). IMMUTABLE_2 resolves to
+    // main_size + 0x20 = 10 + 0x20 = 0x2a. The exact bytecode pins both the convergence and
+    // the literal embedding (no CODESIZE opcode).
+    let main = common::compile_to_bytecode(source).unwrap();
+    assert_eq!(main, "6020602a5f3960205ff3");
+}
+
+#[test]
+fn runtime_codesize_convergence_with_push2_growth() {
+    // Build a MAIN whose runtime size crosses 256 bytes, forcing the embedded PUSH to grow
+    // from PUSH1 to PUSH2 between iterations. Convergence handles it.
+    let pad: String = "00".repeat(260); // 260 bytes of zero bytes embedded as raw hex.
+    let source = format!(
+        r#"
+        #define macro MAIN() = takes(0) returns(0) {{
+            __codesize(RUNTIME) pop
+            __VERBATIM(0x{pad})
+        }}
+    "#
+    );
+
+    let bytecode = common::compile_to_bytecode(&source).unwrap();
+    // Expected: PUSH2 <size> POP <260 zero bytes>. PUSH2 + value (3 bytes) + POP (1) + verbatim (260) = 264 = 0x108.
+    assert!(bytecode.starts_with("610108"), "expected PUSH2 0x0108 prefix, got prefix {}", &bytecode[..8]);
+}
+
+#[test]
+fn runtime_codesize_in_runtime_code_table_errors() {
+    // Code tables can't depend on the runtime size — that would create a circular dependency
+    // in table sizing.
+    let source = r#"
+        #define table T { __codesize(RUNTIME) }
+        #define macro MAIN() = takes(0) returns(0) { __tablestart(T) pop }
+    "#;
+
+    common::assert_compile_error(source, |k| matches!(k, CodegenErrorKind::CodesizeRuntimeInCodeTable));
+}
+
+#[test]
+fn runtime_is_reserved_macro_name() {
+    let source = r#"
+        #define macro RUNTIME() = takes(0) returns(0) { 0x00 }
+        #define macro MAIN() = takes(0) returns(0) { RUNTIME() }
+    "#;
+
+    let full_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(full_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let err = parser.parse().expect_err("expected parser to reject RUNTIME as a macro name");
+    assert!(matches!(err.kind, ParserErrorKind::InvalidMacroName), "got: {err:?}");
+}

--- a/crates/core/tests/common.rs
+++ b/crates/core/tests/common.rs
@@ -44,6 +44,7 @@ pub fn compile_to_deployment(source: &str) -> String {
 
     let evm = &EVMVersion::default();
     let main = Codegen::generate_main_bytecode_with_sourcemap(evm, &contract, None, false).unwrap();
+    contract.runtime_size = Some(main.bytecode.len() / 2);
     let (constructor, updated_contract) = match Codegen::generate_constructor_macro_bytecode(evm, &contract, None, false) {
         Ok((ctor, updated)) => (Some(ctor), updated),
         Err(_) => (None, Codegen::update_table_size(evm, &contract).unwrap()),

--- a/crates/parser/README.md
+++ b/crates/parser/README.md
@@ -66,6 +66,7 @@ fn example() {
       flattened_source: None,
       source_files: vec![],
       source_map: vec![],
+      runtime_size: None,
     };
     assert_eq!(unwrapped_contract.macros, expected_contract.macros);
 }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -579,6 +579,19 @@ impl Parser {
             });
         }
 
+        // RUNTIME is reserved as the magic argument to __codesize(RUNTIME).
+        if macro_name == RUNTIME_CODESIZE_ARG {
+            tracing::error!(target: "parser", "RESERVED MACRO NAME: {RUNTIME_CODESIZE_ARG}");
+            return Err(ParserError {
+                kind: ParserErrorKind::InvalidMacroName,
+                hint: Some(format!(
+                    "{RUNTIME_CODESIZE_ARG} is reserved (used by __codesize({RUNTIME_CODESIZE_ARG})) and cannot be used as a macro name."
+                )),
+                spans: AstSpan(self.spans.clone()),
+                cursor: self.cursor,
+            });
+        }
+
         tracing::info!(target: "parser", "PARSING MACRO: \"{}\"", macro_name);
 
         let macro_arguments = self.parse_args(true, false, false)?;

--- a/crates/utils/src/abi.rs
+++ b/crates/utils/src/abi.rs
@@ -37,6 +37,7 @@
 //!     flattened_source: None,
 //!     source_files: vec![],
 //!     source_map: vec![],
+//!     runtime_size: None,
 //! };
 //!
 //! // Create an ABI using that generate contract

--- a/crates/utils/src/ast/huff.rs
+++ b/crates/utils/src/ast/huff.rs
@@ -8,6 +8,7 @@ use crate::{
     evm_version::EVMVersion,
     opcodes::{OPCODES_MAP, Opcode},
     prelude::{MacroArg::Ident, Span, TokenKind},
+    push_value::PushValue,
 };
 use alloy_primitives::U256;
 use indexmap::IndexMap;
@@ -21,6 +22,10 @@ use std::{
 
 /// A contained literal
 pub type Literal = [u8; 32];
+
+/// Reserved identifier accepted as the argument to `__codesize` to query the byte length of
+/// the runtime section (MAIN body + appended runtime tables). Disallowed as a user macro name.
+pub const RUNTIME_CODESIZE_ARG: &str = "RUNTIME";
 
 /// A File Path
 ///
@@ -62,6 +67,15 @@ pub struct Contract {
     pub source_files: Vec<(String, String)>,
     /// Mapping from flattened position to (file_index, original_position)
     pub source_map: Vec<(usize, usize, usize)>, // (flattened_start, file_id, original_start)
+    /// Byte length of the runtime section. Set before constructor codegen so
+    /// `__codesize(RUNTIME)` resolves; references from any other context error.
+    pub runtime_size: Option<usize>,
+}
+
+/// Returns true if `bf` is a `__codesize(RUNTIME)` call (single identifier arg `RUNTIME`).
+pub fn is_runtime_codesize(bf: &BuiltinFunctionCall) -> bool {
+    matches!(bf.kind, BuiltinFunctionKind::Codesize)
+        && matches!(bf.args.as_slice(), [BuiltinFunctionArg::Identifier(name, _)] if name == RUNTIME_CODESIZE_ARG)
 }
 
 impl Contract {
@@ -518,6 +532,16 @@ impl Contract {
                             BuiltinFunctionKind::Bytes => eval_builtin_bytes(bf)?,
                             BuiltinFunctionKind::RightPad => eval_builtin_pad_simple(bf, PadDirection::Right)?,
                             BuiltinFunctionKind::LeftPad => eval_builtin_pad_simple(bf, PadDirection::Left)?,
+                            // __codesize(RUNTIME) — other __codesize(MACRO) calls depend on
+                            // layout details unavailable in constant context.
+                            _ if is_runtime_codesize(bf) => {
+                                let size = self.runtime_size.ok_or_else(|| CodegenError {
+                                    kind: CodegenErrorKind::RuntimeSizeNotComputed,
+                                    span: span.clone_box(),
+                                    token: None,
+                                })?;
+                                PushValue::from(U256::from(size).to_be_bytes::<32>())
+                            }
                             _ => {
                                 return Err(CodegenError {
                                     kind: CodegenErrorKind::UnsupportedBuiltinFunction(format!("{}", bf.kind)),

--- a/crates/utils/src/error.rs
+++ b/crates/utils/src/error.rs
@@ -223,6 +223,14 @@ pub enum CodegenErrorKind {
     MissingTableSize(String),
     /// Unsupported Builtin Function
     UnsupportedBuiltinFunction(String),
+    /// `__codesize(RUNTIME)` referenced before the runtime size has been computed (e.g. when
+    /// the constructor is compiled in isolation without first generating MAIN).
+    RuntimeSizeNotComputed,
+    /// `__codesize(RUNTIME)` referenced inside a code table. Code tables contribute to the
+    /// runtime size, so embedding the runtime size inside one creates a circular dependency.
+    CodesizeRuntimeInCodeTable,
+    /// MAIN codegen failed to converge on a stable runtime size within the iteration cap.
+    RuntimeSizeNotConverged(usize),
     /// Unsupported Statement Type
     UnsupportedStatementType(String),
     /// Duplicate Label in Same Scope
@@ -356,6 +364,15 @@ impl<W: Write> Report<W> for CodegenError {
             }
             CodegenErrorKind::UnsupportedBuiltinFunction(bf) => {
                 write!(f.out, "Unsupported Builtin Function: \"{bf}\"")
+            }
+            CodegenErrorKind::RuntimeSizeNotComputed => {
+                write!(f.out, "__codesize(RUNTIME) cannot be resolved here: MAIN bytecode has not been generated yet")
+            }
+            CodegenErrorKind::CodesizeRuntimeInCodeTable => {
+                write!(f.out, "__codesize(RUNTIME) is not allowed inside a code table")
+            }
+            CodegenErrorKind::RuntimeSizeNotConverged(iterations) => {
+                write!(f.out, "__codesize(RUNTIME) did not converge after {iterations} MAIN codegen iterations")
             }
             CodegenErrorKind::UnsupportedStatementType(st) => {
                 write!(f.out, "Unsupported Statement Type: \"{st}\"")
@@ -728,6 +745,23 @@ impl fmt::Display for CompilerError {
                 }
                 CodegenErrorKind::UnsupportedBuiltinFunction(bf) => {
                     write!(f, "\nError: Unsupported Builtin Function: \"{bf}\"\n{}\n", ce.span.error(None))
+                }
+                CodegenErrorKind::RuntimeSizeNotComputed => {
+                    write!(
+                        f,
+                        "\nError: __codesize(RUNTIME) cannot be resolved here: MAIN bytecode has not been generated yet\n{}\n",
+                        ce.span.error(None)
+                    )
+                }
+                CodegenErrorKind::CodesizeRuntimeInCodeTable => {
+                    write!(f, "\nError: __codesize(RUNTIME) is not allowed inside a code table\n{}\n", ce.span.error(None))
+                }
+                CodegenErrorKind::RuntimeSizeNotConverged(iterations) => {
+                    write!(
+                        f,
+                        "\nError: __codesize(RUNTIME) did not converge after {iterations} MAIN codegen iterations\n{}\n",
+                        ce.span.error(None)
+                    )
                 }
                 CodegenErrorKind::UnsupportedStatementType(st) => {
                     write!(f, "\nError: Unsupported Statement Type: \"{st}\"\n{}\n", ce.span.error(None))


### PR DESCRIPTION
- Add `__codesize(RUNTIME)`: resolves at compile time to the byte length of the runtime section
  (MAIN body + appended runtime tables). Usable in both MAIN and CONSTRUCTOR (directly or via a
  derived `#define constant`). The self-referential MAIN-side case converges via iterative MAIN
  codegen, bounded by EIP-170 (at most PUSH2). Enables Solidity-style immutables that the
  runtime reads at compile-time literal offsets, with no runtime `codesize` arithmetic. Not
  allowed inside code tables (would create a circular sizing dependency). `RUNTIME` is reserved
  as a macro name.