### PR TITLE
fix(codegen): byte-align odd-nibble constants passed as macro args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+
+## [1.5.17] - 2026-07-27
 - Fix corrupted bytecode when a constant with an odd number of hex digits (e.g. `0x140`) is passed
   as a macro argument. The PUSH data is now byte-aligned, matching the direct `[CONST]` path.
+- Update dependencies.
 
 ## [1.5.16] - 2026-05-31
 - Add `__codesize(RUNTIME)`: resolves at compile time to the byte length of the runtime section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Huff Neo Compiler changelog
 
 ## Unreleased
+- Fix corrupted bytecode when a constant with an odd number of hex digits (e.g. `0x140`) is passed
+  as a macro argument. The PUSH data is now byte-aligned, matching the direct `[CONST]` path.
 
 ## [1.5.16] - 2026-05-31
 - Add `__codesize(RUNTIME)`: resolves at compile time to the byte length of the runtime section

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -2751,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "hnc"
-version = "1.5.16"
+version = "1.5.17"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -4764,7 +4764,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "huff-neo-codegen"
-version = "1.5.16"
+version = "1.5.17"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-core"
-version = "1.5.16"
+version = "1.5.17"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4797,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-js"
-version = "1.5.16"
+version = "1.5.17"
 dependencies = [
  "huff-neo-core",
  "huff-neo-utils",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-lexer"
-version = "1.5.16"
+version = "1.5.17"
 dependencies = [
  "huff-neo-utils",
  "lazy_static",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-parser"
-version = "1.5.16"
+version = "1.5.17"
 dependencies = [
  "alloy-primitives",
  "huff-neo-lexer",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-test-runner"
-version = "1.5.16"
+version = "1.5.17"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "huff-neo-utils"
-version = "1.5.16"
+version = "1.5.17"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/cakevm/huff-neo"
 rust-version = "1.89"
-version = "1.5.16"
+version = "1.5.17"
 
 [workspace.dependencies]
 huff-neo-codegen = { path = "crates/codegen" }

--- a/crates/codegen/src/irgen/arg_calls.rs
+++ b/crates/codegen/src/irgen/arg_calls.rs
@@ -384,8 +384,9 @@ pub fn bubble_arg_call<'a>(
                                 tracing::info!(target: "codegen", "ARGCALL IS CONSTANT: {:?}", const_value);
                                 let push_bytes = match &const_value {
                                     ConstVal::Bytes(bytes) => {
-                                        let hex_literal: String = bytes.as_str().to_string();
-                                        format!("{:02x}{hex_literal}", 95 + hex_literal.len() / 2)
+                                        // Normalize so odd-nibble literals (e.g. 0x140) are byte-aligned,
+                                        // matching the direct `[CONST]` path.
+                                        literal_gen(evm_version, &str_to_bytes32(&bytes.as_str()))
                                     }
                                     ConstVal::String(_s) => {
                                         return Err(CodegenError {

--- a/crates/codegen/src/irgen/arg_calls.rs
+++ b/crates/codegen/src/irgen/arg_calls.rs
@@ -240,32 +240,28 @@ pub fn bubble_arg_call<'a>(
                                         relax_jumps,
                                     );
                                     // Note: macro_to_bytecode already pops the macro from scope_mgr
-                                    match result {
-                                        Ok(expanded) => {
-                                            let byte_len: usize = expanded.bytes.iter().map(|seg| seg.bytes.len()).sum();
-                                            bytes.extend(expanded.bytes);
-                                            *offset += byte_len;
+                                    let expanded = result?;
+                                    let byte_len: usize = expanded.bytes.iter().map(|seg| seg.bytes.len()).sum();
+                                    bytes.extend(expanded.bytes);
+                                    *offset += byte_len;
 
-                                            // Handle jumps and tables
-                                            for jump in expanded.unmatched_jumps {
-                                                if let Some(existing) = jump_table.get_mut(&jump.bytecode_index) {
-                                                    existing.push(jump);
-                                                } else {
-                                                    jump_table.insert(jump.bytecode_index, vec![jump]);
-                                                }
-                                            }
-                                            for table_instance in expanded.table_instances {
-                                                table_instances.push(table_instance);
-                                            }
-                                            for table in expanded.utilized_tables {
-                                                if !utilized_tables.contains(&table) {
-                                                    utilized_tables.push(table);
-                                                }
-                                            }
-                                            return Ok(());
+                                    // Handle jumps and tables
+                                    for jump in expanded.unmatched_jumps {
+                                        if let Some(existing) = jump_table.get_mut(&jump.bytecode_index) {
+                                            existing.push(jump);
+                                        } else {
+                                            jump_table.insert(jump.bytecode_index, vec![jump]);
                                         }
-                                        Err(e) => return Err(e),
                                     }
+                                    for table_instance in expanded.table_instances {
+                                        table_instances.push(table_instance);
+                                    }
+                                    for table in expanded.utilized_tables {
+                                        if !utilized_tables.contains(&table) {
+                                            utilized_tables.push(table);
+                                        }
+                                    }
+                                    return Ok(());
                                 } else {
                                     return Err(CodegenError {
                                         kind: CodegenErrorKind::MissingMacroDefinition(actual_macro_name),
@@ -487,30 +483,26 @@ pub fn bubble_arg_call<'a>(
                                         );
                                         // Note: macro_to_bytecode already pops the macro from scope_mgr
 
-                                        match result {
-                                            Ok(expanded_macro) => {
-                                                let byte_len: usize = expanded_macro.bytes.iter().map(|seg| seg.bytes.len()).sum();
-                                                bytes.extend(expanded_macro.bytes);
-                                                *offset += byte_len;
+                                        let expanded_macro = result?;
+                                        let byte_len: usize = expanded_macro.bytes.iter().map(|seg| seg.bytes.len()).sum();
+                                        bytes.extend(expanded_macro.bytes);
+                                        *offset += byte_len;
 
-                                                // Bubble up jumps and tables
-                                                for unmatched_jump in expanded_macro.unmatched_jumps {
-                                                    let existing_jumps =
-                                                        jump_table.get(&unmatched_jump.bytecode_index).cloned().unwrap_or_else(Vec::new);
-                                                    let mut new_jumps = existing_jumps;
-                                                    new_jumps.push(unmatched_jump.clone());
-                                                    jump_table.insert(unmatched_jump.bytecode_index, new_jumps);
-                                                }
-                                                for table_instance in expanded_macro.table_instances {
-                                                    table_instances.push(table_instance);
-                                                }
-                                                for table in expanded_macro.utilized_tables {
-                                                    if !utilized_tables.contains(&table) {
-                                                        utilized_tables.push(table);
-                                                    }
-                                                }
+                                        // Bubble up jumps and tables
+                                        for unmatched_jump in expanded_macro.unmatched_jumps {
+                                            let existing_jumps =
+                                                jump_table.get(&unmatched_jump.bytecode_index).cloned().unwrap_or_else(Vec::new);
+                                            let mut new_jumps = existing_jumps;
+                                            new_jumps.push(unmatched_jump.clone());
+                                            jump_table.insert(unmatched_jump.bytecode_index, new_jumps);
+                                        }
+                                        for table_instance in expanded_macro.table_instances {
+                                            table_instances.push(table_instance);
+                                        }
+                                        for table in expanded_macro.utilized_tables {
+                                            if !utilized_tables.contains(&table) {
+                                                utilized_tables.push(table);
                                             }
-                                            Err(e) => return Err(e),
                                         }
                                     } else {
                                         return Err(CodegenError {

--- a/crates/codegen/src/irgen/statements.rs
+++ b/crates/codegen/src/irgen/statements.rs
@@ -319,7 +319,7 @@ pub fn statement_gen<'a>(
                 let scope_id = huff_neo_utils::scope::ScopeId::new(vec![], 0);
                 jump_table.insert(
                     *offset + stack_swaps.len() + 3, // PUSH2 + 2 bytes + stack_swaps.len()
-                    vec![Jump { label: format!("goto_{}", &ir_macro.name), bytecode_index: 0, span: s.span.clone(), scope_id }],
+                    vec![Jump { label: format!("goto_{}", ir_macro.name), bytecode_index: 0, span: s.span.clone(), scope_id }],
                 );
 
                 // Get span info for this statement
@@ -348,7 +348,7 @@ pub fn statement_gen<'a>(
                 bytes.push_with_offset(
                     *offset + stack_swaps.len() + 3, // PUSH2 + 2 bytes + stack_swaps.len()
                     Bytes::JumpPlaceholder(JumpPlaceholderData::new(
-                        format!("goto_{}", &ir_macro.name),
+                        format!("goto_{}", ir_macro.name),
                         PushOpcode::Push2,
                         format!("{}{}", Opcode::Jump, Opcode::Jumpdest),
                     )),

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -1447,12 +1447,12 @@ impl Codegen {
                             format!(
                                 "{}{}{}{:04x}{}{}{}{}{:04x}{}{:04x}{}",
                                 Opcode::Push2,    // PUSH2
-                                &tok_len,         // len(bytes)
+                                tok_len,          // len(bytes)
                                 Opcode::Push2,    // PUSH2
                                 len_ptr,          // <len_mem_ptr>
                                 Opcode::Mstore,   // MSTORE
                                 Opcode::Push2,    // PUSH2
-                                &tok_len,         // len(bytes)
+                                tok_len,          // len(bytes)
                                 Opcode::Push2,    // PUSH2
                                 arg_offset_acc,   // <contents_code_ptr>
                                 Opcode::Push2,    // PUSH2

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -229,10 +229,7 @@ impl<'a, 'l> Compiler<'a, 'l> {
                 // Unpack recursed dependencies into FileSources
                 let mut files = vec![];
                 for fs in recursed_file_sources {
-                    match fs {
-                        Ok(f) => files.push(f),
-                        Err(e) => return Err(e),
-                    }
+                    files.push(fs?);
                 }
                 tracing::info!(target: "core", "COMPILER RECURSED {} FILE DEPENDENCIES", files.len());
 
@@ -314,10 +311,7 @@ impl<'a, 'l> Compiler<'a, 'l> {
         // Unpack recursed dependencies into FileSources
         let mut files = vec![];
         for fs in recursed_file_sources {
-            match fs {
-                Ok(f) => files.push(f),
-                Err(e) => return Err(e),
-            }
+            files.push(fs?);
         }
         tracing::info!(target: "core", "COMPILER RECURSED {} FILE DEPENDENCIES", files.len());
 

--- a/crates/core/tests/macro_invoc_args.rs
+++ b/crates/core/tests/macro_invoc_args.rs
@@ -446,6 +446,39 @@ fn test_constant_macro_arg() {
 }
 
 #[test]
+fn test_constant_macro_arg_odd_nibble_literal() {
+    // A constant whose literal has an odd number of hex digits must be byte-aligned
+    // when passed as a macro argument, exactly as when used directly via `[ODD]`.
+    // Emitting the raw literal produced an odd-length, misaligned bytecode.
+    let source = r#"
+            #define constant ODD = 0x140
+
+            #define macro P(v) = takes(0) returns(1) {
+                <v>
+            }
+
+            #define macro MAIN() = takes(0) returns(0) {
+                P(ODD) pop stop
+            }
+        "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    let evm_version = EVMVersion::default();
+
+    let main_bytecode = Codegen::generate_main_bytecode(&evm_version, &contract, None, false).unwrap();
+
+    // PUSH2 0x0140, POP, STOP - left-padded to a whole number of bytes
+    assert_eq!(main_bytecode.to_lowercase(), "6101405000");
+}
+
+#[test]
 fn test_bubbled_label_call_macro_arg() {
     let source = r#"
             #define macro MACRO_A(zero) = takes(0) returns(0) {

--- a/crates/utils/src/file/span.rs
+++ b/crates/utils/src/file/span.rs
@@ -59,7 +59,7 @@ impl Span {
                             "\n     {}|\n  > {} | {}\n     {}|",
                             padding,
                             line_num,
-                            &s[line_start.to_owned()..line_end].replace('\n', ""),
+                            s[line_start.to_owned()..line_end].replace('\n', ""),
                             padding
                         )
                     })

--- a/deny.toml
+++ b/deny.toml
@@ -21,8 +21,26 @@ allow = [
 
 [advisories]
 ignore = [
-  # paste is unmaintained - https://rustsec.org/advisories/RUSTSEC-2024-0436
+  # paste is unmaintained. Compile-time proc-macro dependency only, no runtime impact, and no
+  # maintained drop-in replacement in the pinned dependency graph.
+  # https://rustsec.org/advisories/RUSTSEC-2024-0436
   "RUSTSEC-2024-0436",
+  # crossbeam-utils: invalid pointer deref in the `fmt::Pointer` impl for `Atomic`/`Shared`.
+  # No fixed release exists yet (0.8.22 is latest) and hnc never debug-formats those types.
+  # https://rustsec.org/advisories/RUSTSEC-2026-0204
+  "RUSTSEC-2026-0204",
+  # git2: potential UB in `Remote::list()`. Only pulled transitively (shadow-rs build-time git
+  # info, foundry); hnc does not call the affected API and no newer 0.20.x release is available.
+  # https://rustsec.org/advisories/RUSTSEC-2026-0183
+  "RUSTSEC-2026-0183",
+  # git2: potential UB constructing a `Signature` from a buffer-created `BlameHunk`. Same
+  # transitive-only exposure as above; not reachable from hnc and no fixed release available.
+  # https://rustsec.org/advisories/RUSTSEC-2026-0184
+  "RUSTSEC-2026-0184",
+  # proc-macro-error2 is unmaintained. Compile-time proc-macro dependency only, no runtime
+  # impact, and no maintained drop-in replacement in the pinned dependency graph.
+  # https://rustsec.org/advisories/RUSTSEC-2026-0173
+  "RUSTSEC-2026-0173",
 ]
 yanked = "warn"
 


### PR DESCRIPTION
- Fix corrupted bytecode when a constant with an odd number of hex digits (e.g. `0x140`) is passed
  as a macro argument. The PUSH data is now byte-aligned, matching the direct `[CONST]` path.